### PR TITLE
Fix logging changes

### DIFF
--- a/config/SetupCommon.cmake
+++ b/config/SetupCommon.cmake
@@ -87,6 +87,8 @@ set(COMMON_SOURCE
     eigenrays.hpp
     influence.hpp
     ldio.hpp
+    logging.cpp
+    logging.hpp
     prtfileemu.hpp
     raymode.cpp
     raymode.hpp

--- a/config/cuda/CMakeLists.txt
+++ b/config/cuda/CMakeLists.txt
@@ -24,6 +24,7 @@ include(SetupCUDA.cmake)
 add_executable(bellhopcuda ${COMMON_INCLUDES} ${COMMON_SOURCE} 
     ${CMAKE_SOURCE_DIR}/src/cmdline.cpp
     ${CMAKE_SOURCE_DIR}/src/UtilsCUDA.cuh
+    ${CMAKE_SOURCE_DIR}/src/logging.cu
     ${CMAKE_SOURCE_DIR}/src/run_cuda.cu
 )
 

--- a/config/cuda/SetupCUDA.cmake
+++ b/config/cuda/SetupCUDA.cmake
@@ -20,6 +20,8 @@ option(CUDA_DISASSEMBLY "Save temp outputs for disassembly" OFF)
 set(CUDA_ARCH_OVERRIDE "" CACHE STRING "Compile for this GPU architecture (e.g. 86)")
 
 set(CMAKE_CUDA_STANDARD 14) # C++14
+set(CMAKE_CUDA_SEPARABLE_COMPILATION ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 if(${CMAKE_BUILD_TYPE} STREQUAL "Debug")
 	set(NVCC_DEBUG_FLAGS "-g -G")

--- a/src/UtilsCUDA.cuh
+++ b/src/UtilsCUDA.cuh
@@ -22,7 +22,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 // CUDA Runtime error messages
 #ifdef __DRIVER_TYPES_H__
-static const char *_cudaGetErrorEnum(cudaError_t error) {
+inline const char *_cudaGetErrorEnum(cudaError_t error) {
   return cudaGetErrorName(error);
 }
 #endif
@@ -600,7 +600,10 @@ inline void __syncAndCheckKernelErrors(const char *kernelName, const char *file,
     }else{
         errtype = 1;
     }
-    if(err == cudaSuccess) return;
+    if(err == cudaSuccess){
+        bhc::CudaPostKernelLog();
+        return;
+    }
     cudaDeviceReset();
     throw std::runtime_error(std::string(kernelName) +
         std::string(errtype == 1 ? " launch failed at "

--- a/src/angles.hpp
+++ b/src/angles.hpp
@@ -73,13 +73,13 @@ inline void ReadRayElevationAngles(real freq, real Depth,
     EchoVector(Angles->alpha, Angles->Nalpha, PRTFile);
     
     if(Angles->Nalpha > 1 && Angles->alpha[Angles->Nalpha-1] == Angles->alpha[0]){
-        std::cout << "ReadRayElevationAngles: First and last beam take-off angle are identical\n";
+        GlobalLog("ReadRayElevationAngles: First and last beam take-off angle are identical\n");
         std::abort();
     }
     
     if(TopOpt[5] == 'I'){
         if(Angles->iSingle_alpha < 1 || Angles->iSingle_alpha > Angles->Nalpha){
-            std::cout << "'ReadRayElevationAngles: Selected beam, iSingl not in [1, Angles->Nalpha]\n";
+            GlobalLog("ReadRayElevationAngles: Selected beam, iSingl not in [1, Angles->Nalpha]\n");
             std::abort();
         }
     }

--- a/src/attenuation.hpp
+++ b/src/attenuation.hpp
@@ -172,7 +172,7 @@ inline cpx crci(real z, real c, real alpha, real freq, real freq0, const char (&
     if(alphaT > c){
         PRTFile << "Complex sound speed: " << ret << "\n";
         PRTFile << "Usually this means you have an attenuation that is way too high\n";
-        std::cout << "attenuation: crci: The complex sound speed has an imaginary part > real part\n";
+        GlobalLog("attenuation: crci: The complex sound speed has an imaginary part > real part\n");
     }
     
     return ret;

--- a/src/beams.hpp
+++ b/src/beams.hpp
@@ -30,7 +30,7 @@ inline void ReadPat(std::string FileRoot, PrintFileEmu &PRTFile,
         LDIFile SBPFile(FileRoot, ".sbp");
         if(!SBPFile.Good()){
             PRTFile << "SBPFile = " << FileRoot << ".sbp\n";
-            std::cout << "BELLHOP-ReadPat: Unable to open source beampattern file\n";
+            GlobalLog("BELLHOP-ReadPat: Unable to open source beampattern file\n");
             std::abort();
         }
         
@@ -53,7 +53,7 @@ inline void ReadPat(std::string FileRoot, PrintFileEmu &PRTFile,
     }
     
     if(!monotonic(beaminfo->SrcBmPat, beaminfo->NSBPPts, 2, 0)){
-        std::cout << "BELLHOP-ReadPat: Source beam pattern angles are not monotonic\n";
+        GlobalLog("BELLHOP-ReadPat: Source beam pattern angles are not monotonic\n");
         std::abort();
     }
     
@@ -135,7 +135,7 @@ inline void ReadBeamInfo(LDIFile &ENVFile, PrintFileEmu &PRTFile,
             case 'S':
                 PRTFile << "Standard curvature condition\n"; break;
             default:
-                std::cout << "ReadEnvironment: Unknown curvature condition\n";
+                GlobalLog("ReadEnvironment: Unknown curvature condition\n");
                 std::abort();
             }
             
@@ -154,7 +154,7 @@ inline void ReadBeamInfo(LDIFile &ENVFile, PrintFileEmu &PRTFile,
             PRTFile << "Component                 = " << Beam->Component << "\n";
             break;
         default:
-            std::cout << "ReadEnvironment: Unknown beam type (second letter of run type\n";
+            GlobalLog("ReadEnvironment: Unknown beam type (second letter of run type)\n");
             std::abort();
         }
         

--- a/src/bino.hpp
+++ b/src/bino.hpp
@@ -54,9 +54,8 @@ public:
     #define DOFWRITE(d, data, bytes) d.write(__FILE__, __LINE__, data, bytes)
     void write(const char *file, int fline, const void *data, size_t bytes){
         if(bytesWrittenThisRecord + bytes > recl){
-            std::cout << file << ":" << fline << ": DirectOFile overflow, " 
-                << bytesWrittenThisRecord << " bytes already written, rec size "
-                << recl << ", tried to write " << bytes << " more\n";
+            GlobalLog("%s:%d: DirectOFile overflow, %lli bytes already written, rec size %lli, tried to write %lli more\n",
+                file, fline, bytesWrittenThisRecord, recl, bytes);
             std::abort();
         }
         ostr.write((const char*)data, bytes);
@@ -107,7 +106,7 @@ public:
     
     template<typename T> void write(T v){
         if(recstart < 0){
-            std::cout << "Missing record in UnformattedOFile!\n";
+            GlobalLog("Missing record in UnformattedOFile!\n");
             bail();
         }
         ostr.write((const char*)&v, sizeof(T));
@@ -116,7 +115,7 @@ public:
     
     template<typename T> void write(T *arr, size_t n){
         if(recstart < 0){
-            std::cout << "Missing record in UnformattedOFile!\n";
+            GlobalLog("Missing record in UnformattedOFile!\n");
             bail();
         }
         for(size_t i=0; i<n; ++i) ostr.write((const char*)&arr[i], sizeof(T));

--- a/src/boundary.hpp
+++ b/src/boundary.hpp
@@ -138,7 +138,7 @@ inline void ComputeBdryTangentNormal(BdryPtFull *Bdry, bool isTop, BdryInfo *bdr
     for(int32_t ii=0; ii<NPts-1; ++ii){
         Bdry[ii].t  = Bdry[ii+1].x - Bdry[ii].x;
         Bdry[ii].Dx = Bdry[ii].t[1] / Bdry[ii].t[0]; // first derivative
-        // std::cout << "Dx, t " << Bdry[ii].Dx << " " << Bdry[ii].x << " " << (FL(1.0) / (Bdry[ii].x[1] / FL(500.0)) << "\n";
+        // GlobalLog("Dx, t %g %g %g\n", Bdry[ii].Dx, Bdry[ii].x, (FL(1.0) / (Bdry[ii].x[1] / FL(500.0)));
         
         // normalize the tangent vector
         Bdry[ii].Len = glm::length(Bdry[ii].t);
@@ -179,11 +179,11 @@ inline void ComputeBdryTangentNormal(BdryPtFull *Bdry, bool isTop, BdryInfo *bdr
             Bdry[ii].Dxx   = (Bdry[ii+1].Dx - Bdry[ii].Dx) / // second derivative
                              (Bdry[ii+1].x[0] - Bdry[ii].x[0]); 
             Bdry[ii].Dss   = Bdry[ii].Dxx * CUBE(Bdry[ii].t[0]); // derivative in direction of tangent
-            //std::cout << "kappa, Dss, Dxx " << Bdry[ii].kappa << " " << Bdry[ii].Dss << " " << Bdry[ii].Dxx
-            //    << " " << FL(1.0) / ((FL(8.0) / SQ(FL(1000.0))) * CUBE(STD::abs(Bdry[ii].x[1])))
-            //    << " " << Bdry[ii].x[1] << " "
-            //    << FL(-1.0) / (FL(4.0) * CUBE(Bdry[ii].x[1]) / FL(1000000.0))
-            //    << " " << Bdry[ii].x[1] << "\n";
+            // GlobalLog("kappa, Dss, Dxx %g %g %g %g %g %g %g\n", Bdry[ii].kappa, Bdry[ii].Dss, Bdry[ii].Dxx,
+            //    FL(1.0) / ((FL(8.0) / SQ(FL(1000.0))) * CUBE(STD::abs(Bdry[ii].x[1]))),
+            //    Bdry[ii].x[1],
+            //    FL(-1.0) / (FL(4.0) * CUBE(Bdry[ii].x[1]) / FL(1000000.0)),
+            //    Bdry[ii].x[1]);
             
             Bdry[ii].kappa = Bdry[ii].Dss; // over-ride kappa !!!!!
         }
@@ -206,7 +206,7 @@ inline void ReadATI(std::string FileRoot, char TopATI, real DepthT,
         LDIFile ATIFile(FileRoot + ".ati");
         if(!ATIFile.Good()){
             PRTFile << "ATIFile = " << FileRoot << ".ati\n";
-            std::cout << "ReadATI: Unable to open altimetry file\n";
+            GlobalLog("ReadATI: Unable to open altimetry file\n");
             std::abort();
         }
         
@@ -217,7 +217,7 @@ inline void ReadATI(std::string FileRoot, char TopATI, real DepthT,
         case 'L':
             PRTFile << "Piecewise linear interpolation\n"; break;
         default:
-            std::cout << "ReadATI: Unknown option for selecting altimetry interpolation\n";
+            GlobalLog("ReadATI: Unknown option for selecting altimetry interpolation\n");
             std::abort();
         }
         
@@ -258,12 +258,12 @@ inline void ReadATI(std::string FileRoot, char TopATI, real DepthT,
                 }
                 break;
             default:
-                std::cout << "ReadATI: Unknown option for selecting altimetry option\n";
+                GlobalLog("ReadATI: Unknown option for selecting altimetry option\n");
                 std::abort();
             }
             
             if(bdinfo->Top[ii].x[1] < DepthT){
-                std::cout << "BELLHOP:ReadATI: Altimetry rises above highest point in the sound speed profile\n";
+                GlobalLog("BELLHOP:ReadATI: Altimetry rises above highest point in the sound speed profile\n");
                 std::abort();
             }
         }
@@ -281,7 +281,7 @@ inline void ReadATI(std::string FileRoot, char TopATI, real DepthT,
     ComputeBdryTangentNormal(bdinfo->Top, true, bdinfo);
     
     if(!monotonic(&bdinfo->Top[0].x.x, bdinfo->NATIPts, sizeof(BdryPtFull)/sizeof(real), 0)){
-        std::cout << "BELLHOP:ReadATI: Altimetry ranges are not monotonically increasing\n";
+        GlobalLog("BELLHOP:ReadATI: Altimetry ranges are not monotonically increasing\n");
         std::abort();
     }
 }
@@ -298,7 +298,7 @@ inline void ReadBTY(std::string FileRoot, char BotBTY, real DepthB,
         LDIFile BTYFile(FileRoot + ".bty");
         if(!BTYFile.Good()){
             PRTFile << "BTYFile = " << FileRoot << ".bty\n";
-            std::cout << "ReadATI: Unable to open bathymetry file\n";
+            GlobalLog("ReadATI: Unable to open bathymetry file\n");
             std::abort();
         }
         
@@ -310,7 +310,7 @@ inline void ReadBTY(std::string FileRoot, char BotBTY, real DepthB,
         case 'L':
             PRTFile << "Piecewise linear interpolation\n"; break;
         default:
-            std::cout << "ReadBTY: Unknown option for selecting bathymetry interpolation\n";
+            GlobalLog("ReadBTY: Unknown option for selecting bathymetry interpolation\n");
             std::abort();
         }
         
@@ -332,7 +332,7 @@ inline void ReadBTY(std::string FileRoot, char BotBTY, real DepthB,
             PRTFile << "Range (km)  Depth (m)  alphaR (m/s)  betaR  rho (g/cm^3)  alphaI     betaI\n";
             break;
         default:
-            std::cout << "ReadBTY: Unknown option for selecting bathymetry interpolation\n";
+            GlobalLog("ReadBTY: Unknown option for selecting bathymetry interpolation\n");
             std::abort();
         }
         
@@ -365,12 +365,12 @@ inline void ReadBTY(std::string FileRoot, char BotBTY, real DepthB,
                 }
                 break;
             default:
-                std::cout << "ReadBTY: Unknown option for selecting bathymetry option\n";
+                GlobalLog("ReadBTY: Unknown option for selecting bathymetry option\n");
                 std::abort();
             }
             
             if(bdinfo->Bot[ii].x[1] > DepthB){
-                std::cout << "BELLHOP:ReadBTY: Bathymetry drops below lowest point in the sound speed profile\n";
+                GlobalLog("BELLHOP:ReadBTY: Bathymetry drops below lowest point in the sound speed profile\n");
                 std::abort();
             }
         }
@@ -388,7 +388,7 @@ inline void ReadBTY(std::string FileRoot, char BotBTY, real DepthB,
     ComputeBdryTangentNormal(bdinfo->Bot, false, bdinfo);
     
     if(!monotonic(&bdinfo->Bot[0].x.x, bdinfo->NBTYPts, sizeof(BdryPtFull)/sizeof(real), 0)){
-        std::cout << "BELLHOP:ReadBTY: Bathymetry ranges are not monotonically increasing\n";
+        GlobalLog("BELLHOP:ReadBTY: Bathymetry ranges are not monotonically increasing\n");
         std::abort();
     }
 }
@@ -423,7 +423,7 @@ inline void TopBot(const real &freq, const char (&AttenUnit)[2], real &fT, HSInf
     case 'P':
         PRTFile << "    reading PRECALCULATED IFL\n"; break;
     default:
-       std::cout << "TopBot: Unknown boundary condition type\n";
+       GlobalLog("TopBot: Unknown boundary condition type\n");
        std::abort();
     }
     

--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -77,7 +77,7 @@ int main(int argc, char **argv)
         bhc::FinalizeArrivalsMode(outputs.arrinfo, params.Pos, params.freqinfo,
             params.Beam, FileRoot, false);
     }else{
-        std::cout << "Invalid RunType " << r << "\n";
+        bhc::GlobalLog("Invalid RunType %c\n", r);
         std::abort();
     }
     

--- a/src/common.hpp
+++ b/src/common.hpp
@@ -49,7 +49,6 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 #ifdef BHC_BUILD_CUDA
 #include "cuda_runtime.h"
-#include "UtilsCUDA.cuh"
 #define HOST_DEVICE __host__ __device__
 //Requires libcu++ 1.4 or higher, which is included in the normal CUDA Toolkit
 //install since somewhere between CUDA 11.3 and 11.5. (I.e. 11.5 and later has
@@ -318,6 +317,12 @@ static inline std::string trim_copy(std::string s) {
 #include "bino.hpp"
 #include "prtfileemu.hpp"
 #include "atomics.hpp"
+#include "logging.hpp"
+
+#ifdef BHC_BUILD_CUDA
+#include "UtilsCUDA.cuh"
+#endif
+
 #undef _BHC_INCLUDING_COMPONENTS_
 
 namespace bhc {
@@ -553,36 +558,5 @@ public:
 private:
     std::chrono::high_resolution_clock::time_point tstart;
 };
-
-////////////////////////////////////////////////////////////////////////////////
-// A global log that can stream to an external source (like unreal).
-// Intended to replace calls to printf when stdout is not available.
-// Not thread safe or intended for speed.
-////////////////////////////////////////////////////////////////////////////////
-
-static void (*EXTERNAL_GLOBAL_LOG)(const char* message) = nullptr;
-
-#ifdef BHC_CPU
-inline void GlobalLog(const char* message, ...) {
-	va_list argp;
-	va_start(argp, message);
-	if (EXTERNAL_GLOBAL_LOG == nullptr) {
-		vprintf(message, argp);
-	}
-	else {
-		char* buffer = new char[strlen(message)];
-		vsprintf(buffer, message, argp);
-		EXTERNAL_GLOBAL_LOG(buffer);
-	}
-	va_end(argp);
-}
-#else
-HOST_DEVICE inline void GlobalLog(const char* message, ...) {
-	va_list argp;
-	va_start(argp, message);
-	printf(message, argp); //should be vprintf?
-	va_end(argp);
-}
-#endif
 
 }

--- a/src/common.hpp
+++ b/src/common.hpp
@@ -313,11 +313,11 @@ static inline std::string trim_copy(std::string s) {
 }
 
 #define _BHC_INCLUDING_COMPONENTS_ 1
+#include "logging.hpp"
 #include "ldio.hpp"
 #include "bino.hpp"
 #include "prtfileemu.hpp"
 #include "atomics.hpp"
-#include "logging.hpp"
 
 #ifdef BHC_BUILD_CUDA
 #include "UtilsCUDA.cuh"
@@ -553,7 +553,7 @@ public:
         high_resolution_clock::time_point tend = high_resolution_clock::now();
         double dt = (duration_cast<duration<double>>(tend - tstart)).count();
         dt *= 1000.0;
-        std::cout << dt << " ms\n";
+        GlobalLog("%f ms\n", dt);
     }
 private:
     std::chrono::high_resolution_clock::time_point tstart;

--- a/src/eigenrays.cpp
+++ b/src/eigenrays.cpp
@@ -69,7 +69,7 @@ void FinalizeEigenMode(const bhcParams &params, bhcOutputs &outputs,
 {
     InitRayMode(outputs.rayinfo, params);
     
-    std::cout << (int)outputs.eigen->neigen << " eigenrays\n";
+    GlobalLog("%d eigenrays\n", (int)outputs.eigen->neigen);
     std::vector<std::thread> threads;
     uint32_t cores = singlethread ? 1u : bhc::max(std::thread::hardware_concurrency(), 1u);
     jobID = 0;

--- a/src/ldio.hpp
+++ b/src/ldio.hpp
@@ -145,17 +145,15 @@ public:
     
 private:
     void PrintLoc(){
-        std::cout << codefile << ":" << codeline << " reading " 
-            << _filename << ":" << line  << ": ";
+        GlobalLog("%s:%d reading %s:%d: ", codefile.c_str(), codeline, _filename.c_str(), line);
     }
     void Error(std::string msg){
         PrintLoc();
-        std::cout << msg << "\n";
-        std::cout << "Last token is: \"" << lastitem << "\"\n";
+        GlobalLog("%s\nLast token is: \"%s\"\n", msg.c_str(), lastitem.c_str());
         if(_abort_on_error) std::abort();
     }
     void IgnoreRestOfLine(){
-        if(_debug) std::cout << "-- ignoring rest of line\n";
+        if(_debug) GlobalLog("-- ignoring rest of line\n");
         while(!f.eof() && f.peek() != '\n') f.get();
         if(!f.eof()) f.get(); //get the \n
         ++line;
@@ -164,11 +162,11 @@ private:
     std::string GetNextItem(){
         if(lastitemcount > 0){
             --lastitemcount;
-            if(_debug) std::cout << "-- lastitemcount, returning " << lastitem << "\n";
+            if(_debug) GlobalLog("-- lastitemcount, returning %s\n", lastitem.c_str());
             return lastitem;
         }
         if(isafterslash){
-            if(_debug) std::cout << "-- isafterslash, returning null\n";
+            if(_debug) GlobalLog("-- isafterslash, returning null\n");
             return nullitem;
         }
         //Whitespace before start of item
@@ -187,13 +185,13 @@ private:
         if(f.peek() == ','){
             f.get();
             isafternewline = false;
-            if(_debug) std::cout << "-- empty comma, returning null\n";
+            if(_debug) GlobalLog("-- empty comma, returning null\n");
             return nullitem;
         }
         //Main item
         if(_warnline >= 0 && _warnline != line){
             PrintLoc();
-            std::cout << "Warning: input continues onto next line, likely mistake\n";
+            GlobalLog("Warning: input continues onto next line, likely mistake\n");
             _warnline = line;
         }
         lastitem = "";
@@ -264,7 +262,7 @@ private:
         }
         if(quotemode > 0) Error("Quotes or parentheses not closed");
         if(f.eof()){
-            if(_debug) std::cout << "-- eof, returning " << lastitem << "\n";
+            if(_debug) GlobalLog("-- eof, returning %s\n", lastitem.c_str());
             return lastitem;
         }
         if(quotemode < 0){
@@ -273,11 +271,11 @@ private:
                 + (char)c + std::string("' after end of quoted string"));
         }
         if(isafternewline){
-            if(_debug) std::cout << "-- isafternewline, returning " << lastitem << "\n";
+            if(_debug) GlobalLog("-- isafternewline, returning %s\n", lastitem.c_str());
             return lastitem;
         }
         if(isafterslash){
-            if(_debug) std::cout << "-- new isafterslash, returning " << lastitem << "\n";
+            if(_debug) GlobalLog("-- new isafterslash, returning %s\n", lastitem.c_str());
             return lastitem;
         }
         //Whitespace and comma after item
@@ -307,7 +305,7 @@ private:
         }
         //Finally
         if(lastitemcount > 0) --lastitemcount;
-        if(_debug) std::cout << "-- normal returning " << lastitem << "\n";
+        if(_debug) GlobalLog("-- normal returning %s\n", lastitem.c_str());
         return lastitem;
     }
     

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -16,34 +16,10 @@ PARTICULAR PURPOSE. See the GNU General Public License for more details.
 You should have received a copy of the GNU General Public License along with
 this program. If not, see <https://www.gnu.org/licenses/>.
 */
-#pragma once
 #include "common.hpp"
 
 namespace bhc {
 
-HOST_DEVICE inline void RecordEigenHit(int32_t ir, int32_t iz, 
-    int32_t isrc, int32_t ialpha, int32_t is, EigenInfo *eigen)
-{
-    uint32_t mi = AtomicFetchAdd(&eigen->neigen, 1u);
-    if(mi >= eigen->memsize) return;
-    // GlobalLog("Eigenray hit %d ir %d iz %d isrc %d ialpha %d is %d\n",
-    //     mi, ir, iz, isrc, ialpha, is);
-    eigen->hits[mi].ir = ir;
-    eigen->hits[mi].iz = iz;
-    eigen->hits[mi].isrc = isrc;
-    eigen->hits[mi].ialpha = ialpha;
-    eigen->hits[mi].is = is;
-}
-
-inline void InitEigenMode(EigenInfo *eigen)
-{
-    constexpr uint32_t maxhits = 1000000u;
-    eigen->neigen = 0;
-    eigen->memsize = maxhits;
-    checkallocate(eigen->hits, maxhits);
-}
-
-void FinalizeEigenMode(const bhcParams &params, bhcOutputs &outputs, 
-    std::string FileRoot, bool singlethread);
+void (*external_global_log)(const char *message);
 
 }

--- a/src/logging.cu
+++ b/src/logging.cu
@@ -28,10 +28,11 @@ void CudaPostKernelLog(){
     uint32_t gpos = gpu_log_buf_pos & (gpu_log_buf_size - 1);
     uint32_t &cpos = gpu_log_buf_pos_cpu; // rename to shorter name
     uint32_t len = (gpos < cpos) ? (gpos + gpu_log_buf_size - cpos) : (gpos - cpos);
+    if(len == 0) return;
     char *buf = new char[len+1];
     buf[len] = '\0';
     memcpy(&buf[0], &gpu_log_buf[cpos], std::min(len, gpu_log_buf_size - cpos));
-    if(gpos + len > gpu_log_buf_size){
+    if(cpos + len > gpu_log_buf_size){
         memcpy(&buf[gpu_log_buf_size - cpos], &gpu_log_buf[0], gpos);
     }
     GlobalLogImpl(buf);

--- a/src/logging.cu
+++ b/src/logging.cu
@@ -16,34 +16,27 @@ PARTICULAR PURPOSE. See the GNU General Public License for more details.
 You should have received a copy of the GNU General Public License along with
 this program. If not, see <https://www.gnu.org/licenses/>.
 */
-#pragma once
 #include "common.hpp"
 
 namespace bhc {
 
-HOST_DEVICE inline void RecordEigenHit(int32_t ir, int32_t iz, 
-    int32_t isrc, int32_t ialpha, int32_t is, EigenInfo *eigen)
-{
-    uint32_t mi = AtomicFetchAdd(&eigen->neigen, 1u);
-    if(mi >= eigen->memsize) return;
-    // GlobalLog("Eigenray hit %d ir %d iz %d isrc %d ialpha %d is %d\n",
-    //     mi, ir, iz, isrc, ialpha, is);
-    eigen->hits[mi].ir = ir;
-    eigen->hits[mi].iz = iz;
-    eigen->hits[mi].isrc = isrc;
-    eigen->hits[mi].ialpha = ialpha;
-    eigen->hits[mi].is = is;
-}
+__managed__ char gpu_log_buf[gpu_log_buf_size];
+__managed__ uint32_t gpu_log_buf_pos;
+uint32_t gpu_log_buf_pos_cpu;
 
-inline void InitEigenMode(EigenInfo *eigen)
-{
-    constexpr uint32_t maxhits = 1000000u;
-    eigen->neigen = 0;
-    eigen->memsize = maxhits;
-    checkallocate(eigen->hits, maxhits);
+void CudaPostKernelLog(){
+    uint32_t gpos = gpu_log_buf_pos & (gpu_log_buf_size - 1);
+    uint32_t &cpos = gpu_log_buf_pos_cpu; // rename to shorter name
+    uint32_t len = (gpos < cpos) ? (gpos + gpu_log_buf_size - cpos) : (gpos - cpos);
+    char *buf = new char[len+1];
+    buf[len] = '\0';
+    memcpy(&buf[0], &gpu_log_buf[cpos], std::min(len, gpu_log_buf_size - cpos));
+    if(gpos + len > gpu_log_buf_size){
+        memcpy(&buf[gpu_log_buf_size - cpos], &gpu_log_buf[0], gpos);
+    }
+    GlobalLogImpl(buf);
+    delete[] buf;
+    cpos = gpos;
 }
-
-void FinalizeEigenMode(const bhcParams &params, bhcOutputs &outputs, 
-    std::string FileRoot, bool singlethread);
 
 }

--- a/src/logging.cu
+++ b/src/logging.cu
@@ -24,6 +24,11 @@ __managed__ char gpu_log_buf[gpu_log_buf_size];
 __managed__ uint32_t gpu_log_buf_pos;
 uint32_t gpu_log_buf_pos_cpu;
 
+void CudaInitLog(){
+    gpu_log_buf_pos = 0;
+    gpu_log_buf_pos_cpu = 0;
+}
+
 void CudaPostKernelLog(){
     uint32_t gpos = gpu_log_buf_pos & (gpu_log_buf_size - 1);
     uint32_t &cpos = gpu_log_buf_pos_cpu; // rename to shorter name

--- a/src/logging.hpp
+++ b/src/logging.hpp
@@ -61,12 +61,12 @@ inline void GlobalLogImpl(const char *message){
 HOST_DEVICE inline void GlobalLog(const char *message, ...){
     #ifdef __CUDA_ARCH__
     uint32_t outlen = strlen_d(message);
-    uint32_t pos = atomicAdd(&gpu_log_buf_pos, outlen) & (gpu_log_buf_size - 1);
-    memcpy(&gpu_log_buf[gpu_log_buf_pos], &message[0],
-        ::min((uint32_t)outlen, (uint32_t)(gpu_log_buf_size - pos)));
-    if(pos + outlen > gpu_log_buf_size){
-        memcpy(&gpu_log_buf[0], &message[gpu_log_buf_size - pos],
-            pos + outlen - gpu_log_buf_size);
+    uint32_t startpos = atomicAdd(&gpu_log_buf_pos, outlen) & (gpu_log_buf_size - 1);
+    memcpy(&gpu_log_buf[startpos], &message[0],
+        ::min((uint32_t)outlen, (uint32_t)(gpu_log_buf_size - startpos)));
+    if(startpos + outlen > gpu_log_buf_size){
+        memcpy(&gpu_log_buf[0], &message[gpu_log_buf_size - startpos],
+            startpos + outlen - gpu_log_buf_size);
     }
     #else
     constexpr uint32_t maxbufsize = 1024;

--- a/src/logging.hpp
+++ b/src/logging.hpp
@@ -1,0 +1,94 @@
+/*
+bellhopcxx / bellhopcuda - C++/CUDA port of BELLHOP underwater acoustics simulator
+Copyright (C) 2021-2022 The Regents of the University of California
+c/o Jules Jaffe team at SIO / UCSD, jjaffe@ucsd.edu
+Based on BELLHOP, which is Copyright (C) 1983-2020 Michael B. Porter
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+#pragma once
+
+#ifndef _BHC_INCLUDING_COMPONENTS_
+#error "Must be included from common.hpp!"
+#endif
+
+#include <cstdarg>
+
+namespace bhc {
+
+#ifdef BHC_BUILD_CUDA
+// Must be power of 2 so overflows properly
+constexpr uint32_t gpu_log_buf_size_bits = 20;
+constexpr uint32_t gpu_log_buf_size = 1 << gpu_log_buf_size_bits;
+extern __managed__ char gpu_log_buf[gpu_log_buf_size]; // Circular buffer
+extern __managed__ uint32_t gpu_log_buf_pos;
+extern uint32_t gpu_log_buf_pos_cpu;
+
+__device__ inline int strlen_d(const char *d){
+    int ret = 0;
+    while(d[ret]) ++ret;
+    return ret;
+}
+
+#endif
+
+extern void (*external_global_log)(const char *message);
+
+inline void GlobalLogImpl(const char *message){
+    if(external_global_log != nullptr){
+        external_global_log(message);
+    }else{
+        printf("%s", message);
+    }
+}
+
+/**
+ * Replacement for printf which can be redirected in Unreal (including on GPU).
+ * TODO does not actually print the formatted contents on GPU, just the format
+ * string, due to vsnprintf etc. not being available on the GPU and the
+ * complexity of using a third-party library for this.
+ */
+HOST_DEVICE inline void GlobalLog(const char *message, ...){
+    #ifdef __CUDA_ARCH__
+    uint32_t outlen = strlen_d(message);
+    uint32_t pos = atomicAdd(&gpu_log_buf_pos, outlen) & (gpu_log_buf_size - 1);
+    memcpy(&gpu_log_buf[gpu_log_buf_pos], &message[0],
+        ::min((uint32_t)outlen, (uint32_t)(gpu_log_buf_size - pos)));
+    if(pos + outlen > gpu_log_buf_size){
+        memcpy(&gpu_log_buf[0], &message[gpu_log_buf_size - pos],
+            pos + outlen - gpu_log_buf_size);
+    }
+    #else
+    constexpr uint32_t maxbufsize = 1024;
+    char buf[maxbufsize];
+    va_list argp;
+    va_start(argp, message);
+    vsnprintf(buf, maxbufsize, message, argp);
+    va_end(argp);
+    GlobalLogImpl(buf);
+    #endif
+}
+
+inline void InitLog(void (*outputCallback)(const char *message)){
+    external_global_log = outputCallback;
+    #ifdef BHC_BUILD_CUDA
+    gpu_log_buf_pos = 0;
+    gpu_log_buf_pos_cpu = 0;
+    #endif
+}
+
+#ifdef BHC_BUILD_CUDA
+void CudaPostKernelLog();
+#endif
+
+}

--- a/src/logging.hpp
+++ b/src/logging.hpp
@@ -32,7 +32,6 @@ constexpr uint32_t gpu_log_buf_size_bits = 20;
 constexpr uint32_t gpu_log_buf_size = 1 << gpu_log_buf_size_bits;
 extern __managed__ char gpu_log_buf[gpu_log_buf_size]; // Circular buffer
 extern __managed__ uint32_t gpu_log_buf_pos;
-extern uint32_t gpu_log_buf_pos_cpu;
 
 __device__ inline int strlen_d(const char *d){
     int ret = 0;
@@ -79,16 +78,16 @@ HOST_DEVICE inline void GlobalLog(const char *message, ...){
     #endif
 }
 
+#ifdef BHC_BUILD_CUDA
+void CudaInitLog();
+void CudaPostKernelLog();
+#endif
+
 inline void InitLog(void (*outputCallback)(const char *message)){
     external_global_log = outputCallback;
     #ifdef BHC_BUILD_CUDA
-    gpu_log_buf_pos = 0;
-    gpu_log_buf_pos_cpu = 0;
+    CudaInitLog();
     #endif
 }
-
-#ifdef BHC_BUILD_CUDA
-void CudaPostKernelLog();
-#endif
 
 }

--- a/src/prtfileemu.hpp
+++ b/src/prtfileemu.hpp
@@ -33,7 +33,7 @@ public:
             std::string s(FileRoot);
             ofs.open(s + ".prt");
             if(!ofs.good()){
-                std::cout << "Could not open print file: " << FileRoot << ".prt\n";
+                GlobalLog("Could not open print file: %s.prt\n", FileRoot);
                 bail();
             }
             ofs << std::unitbuf;

--- a/src/raymode.cpp
+++ b/src/raymode.cpp
@@ -30,7 +30,7 @@ void OpenRAYFile(LDOFile &RAYFile, std::string FileRoot, bool ThreeD,
         // Ray trace or Eigenrays
         break;
     default:
-        std::cout << "OpenRAYFile not in ray trace or eigenrays mode\n";
+        GlobalLog("OpenRAYFile not in ray trace or eigenrays mode\n");
         std::abort();
     }
     RAYFile.open(FileRoot + ".ray");

--- a/src/raymode.hpp
+++ b/src/raymode.hpp
@@ -94,7 +94,7 @@ inline bool RunRay(RayInfo *rayinfo, const bhcParams &params, ray2DPt *localmem,
     if(IsRayCopyMode(rayinfo)){
         uint32_t p = AtomicFetchAdd(&rayinfo->NPoints, (uint32_t)Nsteps);
         if(p + Nsteps > rayinfo->MaxPoints){
-            std::cout << "Ran out of memory for rays\n";
+            GlobalLog("Ran out of memory for rays\n");
             rayinfo->results[job].ray2D = nullptr;
             ret = false;
         }else{

--- a/src/readenv.cpp
+++ b/src/readenv.cpp
@@ -62,7 +62,7 @@ void ReadTopOpt(char (&TopOpt)[6], char &bc,
         SSPFile.open(FileRoot + ".ssp");
         if(!SSPFile.good()){
             PRTFile << "SSPFile = " << FileRoot << ".ssp\n";
-            std::cout << BHC_PROGRAMNAME " - ReadEnvironment: Unable to open the SSP file\n";
+            GlobalLog(BHC_PROGRAMNAME " - ReadEnvironment: Unable to open the SSP file\n");
             std::abort();
         }
         } break;
@@ -72,13 +72,13 @@ void ReadTopOpt(char (&TopOpt)[6], char &bc,
         SSPFile.open(FileRoot + ".ssp");
         if(!SSPFile.good()){
             PRTFile << "SSPFile = " << FileRoot << ".ssp\n";
-            std::cout << BHC_PROGRAMNAME " - ReadEnvironment: Unable to open the SSP file\n";
+            GlobalLog(BHC_PROGRAMNAME " - ReadEnvironment: Unable to open the SSP file\n");
         }
         } break;*/
     case 'A':
         PRTFile << "    Analytic SSP option\n"; break;
     default:
-        std::cout << "ReadEnvironment: Unknown option for SSP approximation\n";
+        GlobalLog("ReadEnvironment: Unknown option for SSP approximation\n");
         std::abort();
     }
     
@@ -98,7 +98,7 @@ void ReadTopOpt(char (&TopOpt)[6], char &bc,
     case 'L':
         PRTFile << "    Attenuation units: Loss parameter\n"; break;
     default:
-        std::cout << "ReadEnvironment: Unknown attenuation units\n";
+        GlobalLog("ReadEnvironment: Unknown attenuation units\n");
         std::abort();
     }
     
@@ -133,7 +133,7 @@ void ReadTopOpt(char (&TopOpt)[6], char &bc,
     case ' ':
         break;
     default:
-        std::cout << "ReadEnvironment: Unknown top option letter in fourth position\n";
+        GlobalLog("ReadEnvironment: Unknown top option letter in fourth position\n");
         std::abort();
     }
     
@@ -189,7 +189,7 @@ void ReadRunType(char (&RunType)[7], char (&PlotType)[10],
     case 'a':
        PRTFile << "Arrivals calculation, binary file output\n"; break;
     default:
-       std::cout << "ReadEnvironment: Unknown RunType selected\n";
+       GlobalLog("ReadEnvironment: Unknown RunType selected\n");
        std::abort();
     }
 
@@ -222,7 +222,7 @@ void ReadRunType(char (&RunType)[7], char (&PlotType)[10],
     switch(RunType[4]){
     case 'I':
        PRTFile << "Irregular grid: Receivers at Rr[:] x Rz[:]\n";
-       if(Pos->NRz != Pos->NRr) std::cout << "ReadEnvironment: Irregular grid option selected with NRz not equal to Nr\n";
+       if(Pos->NRz != Pos->NRr) GlobalLog("ReadEnvironment: Irregular grid option selected with NRz not equal to Nr\n");
        memcpy(PlotType, "irregular ", 10);
        break;
     default:
@@ -236,7 +236,7 @@ void ReadRunType(char (&RunType)[7], char (&PlotType)[10],
        PRTFile << "N x 2D calculation (neglects horizontal refraction)\n"; break;
     case '3':
        //PRTFile << "3D calculation\n";
-       std::cout << "3D calculation not supported\n";
+       GlobalLog("3D calculation not supported\n");
        RunType[5] = '2';
        break;
     default:
@@ -263,7 +263,7 @@ void ReadEnvironment(const std::string &FileRoot, PrintFileEmu &PRTFile,
     LDIFile ENVFile(FileRoot + ".env");
     if(!ENVFile.Good()){
         PRTFile << "ENVFile = " << FileRoot << ".env\n";
-        std::cout << BHC_PROGRAMNAME " - ReadEnvironment: Unable to open the environmental file\n";
+        GlobalLog(BHC_PROGRAMNAME " - ReadEnvironment: Unable to open the environmental file\n");
         std::abort();
     }
     
@@ -283,7 +283,7 @@ void ReadEnvironment(const std::string &FileRoot, PrintFileEmu &PRTFile,
     LIST(ENVFile); ENVFile.Read(NMedia);
     PRTFile << "Dummy parameter NMedia = " << NMedia << "\n";
     if(NMedia != 1){
-        std::cout << "ReadEnvironment: Only one medium or layer is allowed in BELLHOP; sediment layers must be handled using a reflection coefficient\n";
+        GlobalLog("ReadEnvironment: Only one medium or layer is allowed in BELLHOP; sediment layers must be handled using a reflection coefficient\n");
     }
     
     ReadTopOpt(Bdry->Top.hs.Opt, Bdry->Top.hs.bc, FileRoot, 
@@ -329,8 +329,8 @@ void ReadEnvironment(const std::string &FileRoot, PrintFileEmu &PRTFile,
     case ' ':
         break;
     default:
-        std::cout << "Unknown bottom option letter in second position: Bdr->Bot.hs.Opt == '" 
-            << Bdry->Bot.hs.Opt << "'\n";
+        GlobalLog("Unknown bottom option letter in second position: Bdr->Bot.hs.Opt == '%c'\n",
+            Bdry->Bot.hs.Opt);
         std::abort();
     }
     

--- a/src/refcoef.hpp
+++ b/src/refcoef.hpp
@@ -98,7 +98,7 @@ inline void ReadReflectionCoefficient(std::string FileRoot, char BotRC, char Top
         LDIFile BRCFile(FileRoot + ".brc");
         if(!BRCFile.Good()){
             PRTFile << "BRCFile = " << FileRoot + ".brc\n";
-            std::cout << "ReadReflectionCoefficient: Unable to open Bottom Reflection Coefficient file\n";
+            GlobalLog("ReadReflectionCoefficient: Unable to open Bottom Reflection Coefficient file\n");
             std::abort();
         }
         
@@ -126,7 +126,7 @@ inline void ReadReflectionCoefficient(std::string FileRoot, char BotRC, char Top
         LDIFile TRCFile(FileRoot + ".trc");
         if(!TRCFile.Good()){
             PRTFile << "TRCFile = " << FileRoot + ".trc\n";
-            std::cout << "ReadReflectionCoefficient: Unable to open Top Reflection Coefficient file\n";
+            GlobalLog("ReadReflectionCoefficient: Unable to open Top Reflection Coefficient file\n");
             std::abort();
         }
         
@@ -149,8 +149,8 @@ inline void ReadReflectionCoefficient(std::string FileRoot, char BotRC, char Top
     // Optionally read in internal reflection coefficient data
     
     if(BotRC == 'P'){
-        std::cout << "Internal reflections not supported by BELLHOP and therefore "
-            "not supported by " BHC_PROGRAMNAME "\n";
+        GlobalLog("Internal reflections not supported by BELLHOP and therefore "
+            "not supported by " BHC_PROGRAMNAME "\n");
         std::abort();
     }
 }

--- a/src/run.hpp
+++ b/src/run.hpp
@@ -63,7 +63,7 @@ inline void InitSelectedMode(const bhcParams &params, bhcOutputs &outputs, bool 
     }else if(params.Beam->RunType[0] == 'A' || params.Beam->RunType[0] == 'a'){
         InitArrivalsMode(outputs.arrinfo, singlethread, params.Pos, *(PrintFileEmu*)params.internal);
     }else{
-        std::cout << "Invalid RunType " << params.Beam->RunType[0] << "\n";
+        GlobalLog("Invalid RunType %c\n", params.Beam->RunType[0]);
         std::abort();
     }
 }

--- a/src/run_cuda.cu
+++ b/src/run_cuda.cu
@@ -48,21 +48,21 @@ void setupGPU()
     for(int g=0; g<num_gpus; ++g){
         checkCudaErrors(cudaGetDeviceProperties(&cudaProperties, g));
         if(g == m_gpu){
-            std::cout << "CUDA device: " << cudaProperties.name << " / compute "
-                << cudaProperties.major << "." << cudaProperties.minor << "\n";
+            GlobalLog("CUDA device: %s / compute %d.%d\n",
+                cudaProperties.name, cudaProperties.major, cudaProperties.minor);
         }
         /*
-        std::cout << ((g == m_gpu) ? "--> " : "    ");
-        std::cout << "GPU " << g << ": " << cudaProperties.name << ", compute SM " 
-            << cudaProperties.major << "." << cudaProperties.minor << "\n";
-        std::cout << "      --Global/shared/constant memory: " 
-            << cudaProperties.totalGlobalMem << ", " 
-            << cudaProperties.sharedMemPerBlock << ", "
-            << cudaProperties.totalConstMem << "\n";
-        std::cout << "      --Warp/threads/SMPs: " 
-            << cudaProperties.warpSize << ", "
-            << cudaProperties.maxThreadsPerBlock << ", "
-            << cudaProperties.multiProcessorCount << "\n";
+        GlobalLog("%s", (g == m_gpu) ? "--> " : "    ");
+        GlobalLog("GPU %d: %s, compute SM %d.%d\n",
+            g, cudaProperties.name, cudaProperties.major, cudaProperties.minor);
+        GlobalLog("      --Global/shared/constant memory: %lli, %d, %d\n",
+            cudaProperties.totalGlobalMem,
+            cudaProperties.sharedMemPerBlock,
+            cudaProperties.totalConstMem);
+        GlobalLog("      --Warp/threads/SMPs: %d, %d, %d\n" ,
+            cudaProperties.warpSize,
+            cudaProperties.maxThreadsPerBlock,
+            cudaProperties.multiProcessorCount);
         */
     }
     
@@ -96,7 +96,7 @@ bool run_cuda(const bhcParams &params, bhcOutputs &outputs)
 BHC_API bool run(const bhcParams &params, bhcOutputs &outputs, bool singlethread)
 {
     if(singlethread){
-        std::cout << "Single threaded mode is nonsense on CUDA, ignoring\n";
+        GlobalLog("Single threaded mode is nonsense on CUDA, ignoring\n");
     }
     if(params.Beam->RunType[0] == 'R'){
         return run_cxx(params, outputs, false);

--- a/src/run_cuda.cu
+++ b/src/run_cuda.cu
@@ -20,8 +20,9 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 
 namespace bhc {
 
+#define MAX_THREADS 256
 __global__ void 
-__launch_bounds__(256, 1)
+__launch_bounds__(MAX_THREADS, 1)
 FieldModesKernel(bhcParams params, bhcOutputs outputs)
 {
     for(int32_t job = blockIdx.x * blockDim.x + threadIdx.x; ; job += gridDim.x * blockDim.x){
@@ -80,7 +81,7 @@ bool run_cuda(const bhcParams &params, bhcOutputs &outputs)
     try{
     
     InitSelectedMode(params, outputs, false);
-    FieldModesKernel<<<d_multiprocs,512>>>(params, outputs);
+    FieldModesKernel<<<d_multiprocs,MAX_THREADS>>>(params, outputs);
     syncAndCheckKernelErrors("FieldModesKernel");
     
     }catch(const std::exception &e){

--- a/src/run_cuda.cu
+++ b/src/run_cuda.cu
@@ -21,7 +21,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 namespace bhc {
 
 __global__ void 
-__launch_bounds__(512, 1)
+__launch_bounds__(256, 1)
 FieldModesKernel(bhcParams params, bhcOutputs outputs)
 {
     for(int32_t job = blockIdx.x * blockDim.x + threadIdx.x; ; job += gridDim.x * blockDim.x){

--- a/src/setup.cpp
+++ b/src/setup.cpp
@@ -38,11 +38,10 @@ BHC_API bool setup(const char *FileRoot, void (*outputCallback)(const char *mess
     bhcParams &params, bhcOutputs &outputs, bool resetParams)
 {
     api_okay = true;
+    InitLog(outputCallback);
     params.internal = new PrintFileEmu(FileRoot, outputCallback);
     PrintFileEmu &PRTFile = *(PrintFileEmu*)params.internal;
 
-    bhc::EXTERNAL_GLOBAL_LOG = outputCallback;
-    
     try {
     
     #ifdef BHC_BUILD_CUDA

--- a/src/sourcereceiver.hpp
+++ b/src/sourcereceiver.hpp
@@ -35,7 +35,7 @@ inline void ReadfreqVec(char BroadbandOption, LDIFile &ENVFile, PrintFileEmu &PR
         PRTFile << "__________________________________________________________________________\n\n\n";
         PRTFile << "Number of frequencies = " << freqinfo->Nfreq << "\n";
         if(freqinfo->Nfreq <= 0){
-            std::cout << "Number of frequencies must be positive\n";
+            GlobalLog("Number of frequencies must be positive\n");
             std::abort();
         }
     }
@@ -66,7 +66,7 @@ template<typename REAL> inline void ReadVector(int32_t &Nx, REAL *&x, std::strin
     PRTFile << "Number of " << Description << " = " << Nx << "\n";
     
     if(Nx <= 0){
-        std::cout << "ReadVector: Number of " << Description << " must be positive\n";
+        GlobalLog("ReadVector: Number of %s must be positive\n", Description.c_str());
         std::abort();
     }
     
@@ -158,11 +158,11 @@ inline void ReadSzRz(real zMin, real zMax, LDIFile &ENVFile, PrintFileEmu &PRTFi
     
     /*
     if(!monotonic(Pos->sz, Pos->NSz)){
-        std::cout << "SzRzRMod: Source depths are not monotonically increasing\n";
+        GlobalLog("SzRzRMod: Source depths are not monotonically increasing\n");
         std::abort();
     }
     if(!monotonic(Pos->rz, Pos->NRz)){
-        std::cout << "SzRzRMod: Receiver depths are not monotonically increasing\n";
+        GlobalLog("SzRzRMod: Receiver depths are not monotonically increasing\n");
         std::abort();
     }
     */
@@ -178,7 +178,7 @@ inline void ReadRcvrRanges(LDIFile &ENVFile, PrintFileEmu &PRTFile,
     if(Pos->NRr != 1) Pos->Delta_r = Pos->Rr[Pos->NRr-1] - Pos->Rr[Pos->NRr-2];
     
     if(!monotonic(Pos->Rr, Pos->NRr)){
-        std::cout << "ReadRcvrRanges: Receiver ranges are not monotonically increasing\n";
+        GlobalLog("ReadRcvrRanges: Receiver ranges are not monotonically increasing\n");
         std::abort();
     }
 }
@@ -195,7 +195,7 @@ inline void ReadRcvrBearings(LDIFile &ENVFile, PrintFileEmu &PRTFile,
     if(Pos->Ntheta != 1) Pos->Delta_theta = Pos->theta[Pos->Ntheta-1] - Pos->theta[Pos->Ntheta-2];
     
     if(!monotonic(Pos->theta, Pos->Ntheta)){
-        std::cout << "ReadRcvrBearings: Receiver bearings are not monotonically increasing\n";
+        GlobalLog("ReadRcvrBearings: Receiver bearings are not monotonically increasing\n");
         std::abort();
     }
 }

--- a/src/ssp.cpp
+++ b/src/ssp.cpp
@@ -67,7 +67,7 @@ void ReadSSP(READ_SSP_ARGS)
         // verify that the depths are monotone increasing
         if(iz > 0){
             if(ssp->z[iz] <= ssp->z[iz-1]){
-                std::cout << "ReadSSP: The depths in the SSP must be monotone increasing (" << ssp->z[iz] << ")\n";
+                GlobalLog("ReadSSP: The depths in the SSP must be monotone increasing (%g)\n", ssp->z[iz]);
                 std::abort();
             }
         }
@@ -83,7 +83,7 @@ void ReadSSP(READ_SSP_ARGS)
             
             ssp->Nz = ssp->NPts;
             if(ssp->NPts == 1){
-                std::cout << "ReadSSP: The SSP must have at least 2 points\n";
+                GlobalLog("ReadSSP: The SSP must have at least 2 points\n");
                 std::abort();
             }
             
@@ -94,7 +94,7 @@ void ReadSSP(READ_SSP_ARGS)
     }
     
     // Fall through means too many points in the profile
-    std::cout << "ReadSSP: Number of SSP points exceeds limit\n";
+    GlobalLog("ReadSSP: Number of SSP points exceeds limit\n");
     std::abort();
 }
 

--- a/src/tlmode.cpp
+++ b/src/tlmode.cpp
@@ -51,7 +51,7 @@ void WriteHeader(DirectOFile &SHDFile, const std::string &FileName,
     
     SHDFile.open(FileName, LRecl);
     if(!SHDFile.good()){
-        std::cout << "Could not open SHDFile: " << FileName << "\n";
+        GlobalLog("Could not open SHDFile: %s\n", FileName.c_str());
         std::abort();
     }
     LRecl /= 4;


### PR DESCRIPTION
Fixes a few issues with the logging changes introduced as part of the UpdateSSP changes.
- Regular bugs fixed.
- Use of `std::cout` is also replaced with logging, as well as `printf`. Previously only the latter was.
- Log messages from the GPU are also collected and sent to the logging callback on the CPU. However, this only logs the printf format string itself, not the data contents. `vsnprintf` required for the latter is not available on the GPU; there is a third-party library with it, but it is not trivial to integrate and it may slow things down. Anyway, most printf messages are errors and don't contain any data.