### PR TITLE
Fixes build error caused by trying to print cuda complex type with std::ofstream

### DIFF
--- a/src/module/atten.cpp
+++ b/src/module/atten.cpp
@@ -184,7 +184,7 @@ template<bool O3D> cpx crci(
     ret = cpx(c, alphaT);
 
     if(alphaT > c) {
-        PRTFile << "Complex sound speed: " << ret << "\n";
+        PRTFile << "Complex sound speed: " << std::complex<real>(ret.real(), ret.imag()) << "\n";
         PRTFile << "Usually this means you have an attenuation that is way too high\n";
         EXTWARN("attenuation: crci: The complex sound speed has an imaginary part > "
                 "real part");


### PR DESCRIPTION
Related to issue #23.

Now it is building on arch linux, with gcc13 and CUDA 12.2