### PR TITLE
stale rlen fix

### DIFF
--- a/src/influence.hpp
+++ b/src/influence.hpp
@@ -1367,7 +1367,7 @@ template<typename CFG, bool O3D, bool R3D> HOST_DEVICE inline bool Step_Influenc
 
                     // linear interpolation of q's.
                     // proportional distance along ray
-                    real s = glm::dot(x_rcvr_ray, rayt) / rlen;
+                    real s = glm::dot(x_rcvr_ray, rayt) / glm::length(x_rcvr_ray);
                     // normal distance to ray
                     real n1 = STD::abs(glm::dot(x_rcvr_ray, rayn1));
                     real n2 = NAN;


### PR DESCRIPTION
Fix a normalization error in the bellhop algorithm. Note this error was present in the original fortran, too.
Test
A set of environment, bathymetry, and sound speed files that replicate the error are available [here](https://drive.google.com/drive/folders/1u6_mhf1yF-NyFGAgiukKXnr4pjGVZBdK?usp=drive_link), along with notes.
