### PR TITLE
Eigen arrival

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,8 @@ test/in/genperf_*
 test/in/genrev_*
 
 test/in/*.prt
+
+test/individual/**/*.prt
+test/individual/**/*.ray
+test/individual/**/*.arr
+test/individual/**/*.shd

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -376,7 +376,7 @@ template<bool O3D, bool R3D> inline mode::ModeModule<O3D, R3D> *GetMode(
     } else if(IsArrivalsRun(params.Beam)) {
         return new mode::Arr<O3D, R3D>();
     } else {
-        EXTERR("Invalid RunType %c\n", params.Beam->RunType[0]);
+        EXTERR("Invalid RunType (GetMode) %c\n", params.Beam->RunType[0]);
         // return nullptr;
     }
 }
@@ -401,6 +401,9 @@ template<bool O3D, bool R3D> bool run(
 
         sw.tick();
         mo->Postprocess(params, outputs);
+        if(IsAlsoEigenraysRun(params.Beam)) {
+            mode::PostProcessEigenrays(params, outputs);
+        }
         sw.tock("Postprocess");
 
         delete mo;
@@ -435,6 +438,10 @@ template<bool O3D, bool R3D> bool writeout(
         if(FileRoot != nullptr) { GetInternal(params)->FileRoot = FileRoot; }
         auto *mo = GetMode<O3D, R3D>(params);
         mo->Writeout(params, outputs);
+        if(IsAlsoEigenraysRun(params.Beam)) {
+            mode::Eigen<O3D, R3D> E1;
+            E1.Writeout(params, outputs);
+        }
         sw.tock("writeout");
         delete mo;
     } catch(const std::exception &e) {

--- a/src/influence.hpp
+++ b/src/influence.hpp
@@ -445,6 +445,10 @@ template<typename CFG, bool O3D, bool R3D> HOST_DEVICE inline void ApplyContribu
         AddArr<R3D>(
             itheta, iz, ir, cnst * w, omega, phaseInt, delay, inflray.init, RcvrDeclAngle,
             RcvrAzimAngle, point1.NumTopBnc, point1.NumBotBnc, arrinfo, Pos);
+        if(IsAlsoEigenraysRun(Beam)) {
+            // TODO: check how much this if statement costs
+            RecordEigenHit(itheta, ir, iz, is, inflray.init, eigen);
+        }
     } else {
         cpxf dfield;
         if(IsCoherentRun(Beam)) {

--- a/src/mode/arr.cpp
+++ b/src/mode/arr.cpp
@@ -95,6 +95,7 @@ template<bool O3D> void WriteOutArrivals(
     LDOFile AARRFile;
     UnformattedOFile BARRFile(GetInternal(params));
     switch(params.Beam->RunType[0]) {
+    case 'V': // ascii arrivals and eigenrays
     case 'A': // arrivals calculation, ascii
         isAscii = true;
 
@@ -128,6 +129,7 @@ template<bool O3D> void WriteOutArrivals(
             AARRFile << '\n';
         }
         break;
+    case 'v': // binary arrivals and eigenrays
     case 'a': // arrivals calculation, binary
         isAscii = false;
 

--- a/src/mode/arr.hpp
+++ b/src/mode/arr.hpp
@@ -19,6 +19,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #pragma once
 #include "../common_setup.hpp"
 #include "field.hpp"
+#include "eigen.hpp"
 
 namespace bhc { namespace mode {
 
@@ -97,6 +98,11 @@ public:
         memset(arrinfo->Arr, 0, nSrcsRcvrs * (size_t)arrinfo->MaxNArr * sizeof(Arrival));
         memset(arrinfo->NArr, 0, nSrcsRcvrs * sizeof(int32_t));
         // MaxNPerSource does not have to be initialized
+
+        if(IsAlsoEigenraysRun(params.Beam)) {
+            Eigen<O3D, R3D> E1;
+            E1.Preprocess(params, outputs);
+        }
     }
 
     virtual void Postprocess(
@@ -109,6 +115,10 @@ public:
         const bhcParams<O3D> &params, const bhcOutputs<O3D, R3D> &outputs) const override
     {
         WriteOutArrivals<O3D>(params, outputs.arrinfo);
+        if(params.Beam->RunType[0] == 'v' || params.Beam->RunType[0] == 'V') {
+            Eigen<O3D, R3D> E1;
+            E1.Writeout(params, outputs);
+        }
     }
 
     virtual void Readout(

--- a/src/mode/field.cpp
+++ b/src/mode/field.cpp
@@ -111,7 +111,7 @@ template<char IT, bool O3D, bool R3D> inline void RunFieldModesSelRun(
         EXTERR("Eigenrays runs (Beam->RunType[0] == 'E') "
                "were not enabled at compile time!");
 #endif
-    } else if(rt == 'A' || rt == 'a') {
+    } else if(rt == 'A' || rt == 'a' || rt == 'V' || rt == 'v') {
 #ifdef BHC_RUN_ENABLE_ARRIVALS
         if constexpr(InflType<IT>::IsCerveny()) {
             EXTERR("Cerveny influence does not support arrivals!");
@@ -119,7 +119,7 @@ template<char IT, bool O3D, bool R3D> inline void RunFieldModesSelRun(
             RunFieldModesSelSSP<'A', IT, O3D, R3D>(params, outputs);
         }
 #else
-        EXTERR("Arrivals runs (Beam->RunType[0] == 'A' or 'a') "
+        EXTERR("Arrivals runs (Beam->RunType[0] == 'A', 'a', 'V', or 'v') "
                "were not enabled at compile time!");
 #endif
     } else if(rt == 'R') {

--- a/src/mode/ray.hpp
+++ b/src/mode/ray.hpp
@@ -77,7 +77,7 @@ public:
 
         trackdeallocate(params, rayinfo->RayMem);
         trackdeallocate(params, rayinfo->WorkRayMem);
-        rayinfo->NRays = IsEigenraysRun(params.Beam)
+        rayinfo->NRays = IsEigenraysRun(params.Beam) || IsAlsoEigenraysRun(params.Beam)
             ? outputs.eigen->neigen
             : GetNumJobs<O3D>(params.Pos, params.Angles);
         trackallocate(params, "ray metadata", rayinfo->results, rayinfo->NRays);
@@ -168,7 +168,8 @@ private:
     inline void OpenRAYFile(
         LDOFile &RAYFile, std::string FileRoot, const bhcParams<O3D> &params) const
     {
-        if(!IsRayRun(params.Beam) && !IsEigenraysRun(params.Beam)) {
+        if(!IsRayRun(params.Beam) && !IsEigenraysRun(params.Beam)
+           && !IsAlsoEigenraysRun(params.Beam)) {
             EXTERR("OpenRAYFile not in ray trace or eigenrays mode");
         }
         RAYFile.open(FileRoot + ".ray");

--- a/src/module/runtype.hpp
+++ b/src/module/runtype.hpp
@@ -61,6 +61,8 @@ public:
         case 'C': break;
         case 'A': break;
         case 'a': break;
+        case 'V': break;
+        case 'v': break;
         default: EXTERR("ReadEnvironment: Unknown RunType selected");
         }
 
@@ -125,6 +127,8 @@ public:
         case 'C': PRTFile << "Coherent TL calculation\n"; break;
         case 'A': PRTFile << "Arrivals calculation, ASCII  file output\n"; break;
         case 'a': PRTFile << "Arrivals calculation, binary file output\n"; break;
+        case 'V': PRTFile << "Arrival/Eigenray calculation, ASCII  file output\n"; break;
+        case 'v': PRTFile << "Arrival/Eigenray calculation, binary file output\n"; break;
         }
 
         switch(params.Beam->RunType[1]) {

--- a/src/runtype.hpp
+++ b/src/runtype.hpp
@@ -110,7 +110,14 @@ template<bool O3D> HOST_DEVICE inline bool IsEigenraysRun(const BeamStructure<O3
 template<bool O3D> HOST_DEVICE inline bool IsArrivalsRun(const BeamStructure<O3D> *Beam)
 {
     char r = Beam->RunType[0];
-    return r == 'A' || r == 'a';
+    return r == 'A' || r == 'a' || r == 'V' || r == 'v';
+}
+
+template<bool O3D> HOST_DEVICE inline bool IsAlsoEigenraysRun(
+    const BeamStructure<O3D> *Beam)
+{
+    char r = Beam->RunType[0];
+    return r == 'V' || r == 'v';
 }
 
 template<bool O3D> HOST_DEVICE inline bool IsCoherentRun(const BeamStructure<O3D> *Beam)

--- a/test/individual/eigen_arrival/arrival.env
+++ b/test/individual/eigen_arrival/arrival.env
@@ -1,0 +1,30 @@
+'Eigen_arrival'	! TITLE
+50.0				! FREQ (Hz)
+1				! NMEDIA
+'CVW'				! SSPOPT (Analytic or C-linear interpolation)
+5  0.0  5000.0			! DEPTH of bottom (m)
+    0.0  1548.52  /
+  400.0  1517.78  /
+ 1000.0  1501.38  /
+ 3000.0  1518.67  /
+ 5000.0  1551.91  /
+'A' 0.0
+ 5000.0  1600.00 0.0 1.8 0.8 /
+1                 ! Nsx number of source coordinates in x
+0.0 /  				! x coordinate of source (km)
+1                 ! Nsy number of source coordinates in y
+0.0 /  				! y coordinate of source (km)
+1                 ! NSD
+500.0 /          ! SD(1:NSD) (m)
+1               ! NRD
+200.01 5000 /		! RD(1:NRD) (m)
+2               ! NR
+2.0  2.1 /		! R(1:NR ) (km)
+1                ! Ntheta (number of bearings)
+0.0 11.0 /       ! bearing angles (degrees)
+'Ag   3'              ! 'R/C/I/S'
+11                 ! Nalpha
+-10 10 /    ! alpha1, 2 (degrees) Elevation/declination angle fan
+2               ! Nbeta
+0 0.1   /    ! beta1, beta2 (degrees) bearine angle fan
+0.0  199.1 199.1 2500.0 ! STEP (m), Box%x (km) Box%y (km) Box%z (m)

--- a/test/individual/eigen_arrival/eigen.env
+++ b/test/individual/eigen_arrival/eigen.env
@@ -1,0 +1,30 @@
+'Eigen_arrival'	! TITLE
+50.0				! FREQ (Hz)
+1				! NMEDIA
+'CVW'				! SSPOPT (Analytic or C-linear interpolation)
+5  0.0  5000.0			! DEPTH of bottom (m)
+    0.0  1548.52  /
+  400.0  1517.78  /
+ 1000.0  1501.38  /
+ 3000.0  1518.67  /
+ 5000.0  1551.91  /
+'A' 0.0
+ 5000.0  1600.00 0.0 1.8 0.8 /
+1                 ! Nsx number of source coordinates in x
+0.0 /  				! x coordinate of source (km)
+1                 ! Nsy number of source coordinates in y
+0.0 /  				! y coordinate of source (km)
+1                 ! NSD
+500.0 /          ! SD(1:NSD) (m)
+1               ! NRD
+200.01 5000 /		! RD(1:NRD) (m)
+2               ! NR
+2.0  2.1 /		! R(1:NR ) (km)
+1                ! Ntheta (number of bearings)
+0.0 11.0 /       ! bearing angles (degrees)
+'Eg   3'              ! 'R/C/I/S'
+11                 ! Nalpha
+-10 10 /    ! alpha1, 2 (degrees) Elevation/declination angle fan
+2               ! Nbeta
+0 0.1   /    ! beta1, beta2 (degrees) bearine angle fan
+0.0  199.1 199.1 2500.0 ! STEP (m), Box%x (km) Box%y (km) Box%z (m)

--- a/test/individual/eigen_arrival/eigen_arrival.env
+++ b/test/individual/eigen_arrival/eigen_arrival.env
@@ -1,0 +1,30 @@
+'Eigen_arrival'	! TITLE
+50.0				! FREQ (Hz)
+1				! NMEDIA
+'CVW'				! SSPOPT (Analytic or C-linear interpolation)
+5  0.0  5000.0			! DEPTH of bottom (m)
+    0.0  1548.52  /
+  400.0  1517.78  /
+ 1000.0  1501.38  /
+ 3000.0  1518.67  /
+ 5000.0  1551.91  /
+'A' 0.0
+ 5000.0  1600.00 0.0 1.8 0.8 /
+1                 ! Nsx number of source coordinates in x
+0.0 /  				! x coordinate of source (km)
+1                 ! Nsy number of source coordinates in y
+0.0 /  				! y coordinate of source (km)
+1                 ! NSD
+500.0 /          ! SD(1:NSD) (m)
+1               ! NRD
+200.01 5000 /		! RD(1:NRD) (m)
+2               ! NR
+2.0  2.1 /		! R(1:NR ) (km)
+1                ! Ntheta (number of bearings)
+0.0 11.0 /       ! bearing angles (degrees)
+'Vg   3'              ! 'R/C/I/S'
+11                 ! Nalpha
+-10 10 /    ! alpha1, 2 (degrees) Elevation/declination angle fan
+2               ! Nbeta
+0 0.1   /    ! beta1, beta2 (degrees) bearine angle fan
+0.0  199.1 199.1 2500.0 ! STEP (m), Box%x (km) Box%y (km) Box%z (m)

--- a/test/individual/readme.txt
+++ b/test/individual/readme.txt
@@ -1,0 +1,3 @@
+These are individual tests intended to check for reasonable numeric results, independent of comparisons with Acoustic Toolbox BELLHOP.
+
+eigen_arrival: Test the 'V' and 'v' modes that generate both arrivals and associated eigenrays. Mostly a test that the output files are generated and parse. compare the files from 'V', 'E', and 'A' modes (and/or associated binary versions with lower case letters). Note that it works around bugs in how influence is identified by using two receivers.


### PR DESCRIPTION
Add the options 'V' and 'v' to store arrival and eigenray information in the same run. 

Test - code review and check that the env files in tests/indivdual/eigen_arrival generate the same output. eigen_arrival.env runs both eigen and arrival and generates .ray and .arr. eigen.env and arrival.env run the same system, but just do eigen and arrival alone.

Closes #35 