### PR TITLE
Patch for cuda 12.9 and gcc 13.3

### DIFF
--- a/src/common.hpp
+++ b/src/common.hpp
@@ -414,7 +414,7 @@ struct bhcInternal {
     void (*completedCallback)();
     std::string FileRoot;
     PrintFileEmu PRTFile;
-    std::atomic<int32_t> sharedJobID;
+    STD::atomic<int32_t> sharedJobID;
     int gpuIndex, d_multiprocs; // d_warp, d_maxthreads
     int32_t numThreads;
     size_t maxMemory;
@@ -422,9 +422,9 @@ struct bhcInternal {
     bool useRayCopyMode;
     bool noEnvFil;
     uint8_t dim;
-    std::atomic<int32_t> totalJobs;
-    std::atomic<int32_t> activeThreadCount;
-    std::atomic<int32_t> completedRayCount;
+    STD::atomic<int32_t> totalJobs;
+    STD::atomic<int32_t> activeThreadCount;
+    STD::atomic<int32_t> completedRayCount;
     ErrState errState;
 
     bhcInternal(const bhcInit &init, bool o3d, bool r3d)


### PR DESCRIPTION
There seems to be a namespace issue/change with cuda-12.9 and gcc-13.3.

Earlier this week, I was able to compile the main branch with cuda-12.1 and gcc-12.3 (after one small change, which was apparently already in dev) but could not with cuda-12.9 and gcc-13.3. After updating the namespace, both versions of cuda and gcc would compile and produced the same results.

Just tested on the dev branch before creating the PR.


Some system info:
Ubuntu 24.04 
GPU: GeForce RTX 3090
NVIDIA Driver Version: 535.230.02

