### PR TITLE
fix: Align StepToBdry step size with Fortran implementation

### DIFF
--- a/src/step.hpp
+++ b/src/step.hpp
@@ -353,8 +353,9 @@ template<bool O3D> HOST_DEVICE inline void StepToBdry(
 #ifdef STEP_DEBUGGING
     printf("StepToBdry\n");
 #endif
+    // don't use Original step
     // Original step due to maximum step size
-    h       = Beam->deltas;
+    // h       = Beam->deltas;
     x2      = x0 + h * urayt;
     snapDim = -1;
 


### PR DESCRIPTION
The StepToBdry function was overriding the reduced step size (h) computed by ReduceStep(), leading to significant discrepancies in ray parameters p and q compared to the Fortran version. This commit comments out the line resetting h to Beam->deltas, preserving the reduced step size and improving numerical consistency with the original Fortran implementation. Fixes:
~20% deviation in p/q parameters at 30km range
In the MunkB_Coh.env example, the Mean Absolute Error (MAE) of Sound Transmission Loss (TL) calculations reduced from 3.65dB to 0.0286dB Tested against Fortran version: http://oalib.hlsresearch.com/AcousticsToolbox/ (2024_12_25)