### PR TITLE
don't clobber step size

### DIFF
--- a/src/step.hpp
+++ b/src/step.hpp
@@ -353,8 +353,6 @@ template<bool O3D> HOST_DEVICE inline void StepToBdry(
 #ifdef STEP_DEBUGGING
     printf("StepToBdry\n");
 #endif
-    // Original step due to maximum step size
-    h       = Beam->deltas;
     x2      = x0 + h * urayt;
     snapDim = -1;
 


### PR DESCRIPTION
Implement the bug identified by perry4401 in https://github.com/A-New-BellHope/bellhopcuda/pull/48
Tested by running the 3D coverage tests from OALIB.
Note: this aligns BHC with results from OALIB in the ongoing issues with eigenrays.