### PR TITLE
Variable bottom

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -24,7 +24,7 @@
       "variables": [
         {
           "name": "BHC_ENABLE_CUDA",
-          "value": "False",
+          "value": "True",
           "type": "BOOL"
         }
       ]

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -24,7 +24,7 @@
       "variables": [
         {
           "name": "BHC_ENABLE_CUDA",
-          "value": "True",
+          "value": "False",
           "type": "BOOL"
         }
       ]

--- a/config/examples/CMakeLists.txt
+++ b/config/examples/CMakeLists.txt
@@ -31,5 +31,6 @@ endfunction()
 
 create_example(background)
 create_example(defaults)
+create_example(province)
 create_example(readout)
 create_example(writeenv)

--- a/examples/province.cpp
+++ b/examples/province.cpp
@@ -1,0 +1,198 @@
+/*
+bellhopcxx / bellhopcuda - C++/CUDA port of BELLHOP(3D) underwater acoustics simulator
+Copyright (C) 2021-2023 The Regents of the University of California
+Marine Physical Lab at Scripps Oceanography, c/o Jules Jaffe, jjaffe@ucsd.edu
+Based on BELLHOP / BELLHOP3D, which is Copyright (C) 1983-2022 Michael B. Porter
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include <iostream>
+#include <vector>
+
+// This define must be set before including the header if you're using the DLL
+// version on Windows, and it must NOT be set if you're using the static library
+// version on Windows. If you're not on Windows, it doesn't matter either way.
+#define BHC_DLL_IMPORT 1
+#include <bhc/bhc.hpp>
+
+// Test for the province code.
+// Should match the provinces test in the source matlab.
+// Also an example for how to run transmission loss in
+// a simple environment from library interface.
+// Not intended to be general.
+
+void OutputCallback(const char *message)
+{
+    std::cout << "Out: " << message << std::endl << std::flush;
+}
+
+void PrtCallback(const char *message) { std::cout << message << std::flush; }
+
+// Helper to setup vectors from ranges. No checking.
+template<class T> void SetupVector(T *arr, T low, T high, int size)
+{
+    for(int i = 0; i < size; ++i) {
+        arr[i] = low + double(i) / double(size - 1) * (high - low);
+    }
+}
+
+// Helper to setup boundaries. Not very general.
+void FlatBoundary3D(
+    bhc::BdryInfoTopBot<true> &Boundary, const double &Depth,
+    const std::vector<double> &GridX, const std::vector<double> &GridY)
+{
+    Boundary.dirty     = true;
+    Boundary.rangeInKm = true;
+    Boundary.NPts[0]   = GridX.size();
+    Boundary.NPts[1]   = GridY.size();
+
+    for(int iy = 0; iy < GridY.size(); ++iy) {
+        for(int ix = 0; ix < GridX.size(); ++ix) {
+            Boundary.bd[ix * GridY.size() + iy].x.x = GridX[ix];
+            Boundary.bd[ix * GridY.size() + iy].x.y = GridY[iy];
+            Boundary.bd[ix * GridY.size() + iy].x.z = Depth;
+        }
+    }
+}
+
+// Hacked in map for the provinces to match a local test. Note province is 1 based.
+int GetProvince(int ix, int iy)
+{
+    if(ix < 5) {
+        if(iy < 10) {
+            return 3;
+        } else {
+            return 2;
+        }
+    } else {
+        if(iy < 10) {
+            return 4;
+        } else {
+            return 1;
+        }
+    }
+
+    // shouldn't get here
+    return 1;
+}
+
+int main()
+{
+    bhc::bhcParams<true> params;
+    bhc::bhcOutputs<true, true> outputs;
+    bhc::bhcInit init;
+    init.FileRoot       = nullptr;
+    init.outputCallback = OutputCallback;
+    init.prtCallback    = PrtCallback;
+
+    bhc::setup(init, params, outputs);
+
+    strcpy(params.Title, "library province test");
+
+    strcpy(params.Beam->RunType, "IG   3");
+
+    params.freqinfo->freq0 = 100.0;
+
+    // flat sound speed
+    params.ssp->NPts = 3;
+    params.ssp->Nz   = 3;
+    params.ssp->z[0] = 0.0;
+    params.ssp->z[1] = 100.0;
+    params.ssp->z[2] = 20000.0;
+    for(int32_t i = 0; i < 3; ++i) {
+        params.ssp->alphaR[i] = 1500.0;
+        params.ssp->alphaI[i] = 0.0;
+        params.ssp->rho[i]    = 1.0;
+        params.ssp->betaR[i]  = 0.0;
+        params.ssp->betaI[i]  = 0.0;
+    }
+
+    // bottom params, mostly overridden, but makes the output file.
+    strcpy(params.Bdry->Bot.hs.Opt, "A~    ");
+    params.Bdry->Bot.hsx.Sigma = 0.0;
+    params.Bdry->Bot.hsx.zTemp = 20000.0;
+    params.Bdry->Bot.hs.alphaR = 1600.0;
+    params.Bdry->Bot.hs.betaR  = 0.0;
+    params.Bdry->Bot.hs.rho    = 1.8;
+    params.Bdry->Bot.hs.alphaI = 0.8;
+    params.Bdry->Bot.hs.betaI  = 0.0;
+    params.Bdry->Bot.hs.Depth  = 20000.0;
+
+    // flat top and bottom, variable bottom sound speed
+    bhc::extsetup_altimetry(params, {2, 2});
+    FlatBoundary3D(params.bdinfo->top, 0.0, {-10.0, 10.0}, {-10.0, 10.0});
+    bhc::extsetup_bathymetry(params, {11, 21}, 5);
+    FlatBoundary3D(
+        params.bdinfo->bot, 100.0,
+        {-10.0, -8.0, -6.0, -4.0, -2.0, 0.0, 2.0, 4.0, 6.0, 8.0, 10.0},
+        {-10.0, -9.0, -8.0, -7.0, -6.0, -5.0, -4.0, -3.0, -2.0, -1.0, 0.0,
+         1.0,   2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  8.0,  9.0,  10.0});
+    for(int ix = 0; ix < 11; ++ix) {
+        for(int iy = 0; iy < 21; ++iy) {
+            params.bdinfo->bot.bd[ix * 21 + iy].Province = GetProvince(ix, iy);
+        }
+    }
+    int cnt = 0;
+    for(auto spd : {1500.0, 1550.0, 1600.0, 1650.0, 1650.0}) {
+        params.bdinfo->bot.BotProv[cnt].alphaR = spd;
+        params.bdinfo->bot.BotProv[cnt].betaR  = 0.0;
+        params.bdinfo->bot.BotProv[cnt].rho    = 1.8;
+        params.bdinfo->bot.BotProv[cnt].alphaI = 0.8;
+        params.bdinfo->bot.BotProv[cnt].betaI  = 0.0;
+        ++cnt;
+    }
+    strcpy(params.bdinfo->bot.type, "RL");
+
+    params.bdinfo->top.dirty = true;
+    params.bdinfo->bot.dirty = true;
+
+    // one source
+    bhc::extsetup_sxsy(params, 1, 1);
+    bhc::extsetup_sz(params, 1);
+    params.Pos->Sx[0] = 0.0f;
+    params.Pos->Sy[0] = 0.0f;
+    params.Pos->Sz[0] = 50.0f;
+
+    // disk of receivers
+    params.Pos->RrInKm = true;
+    bhc::extsetup_rcvrbearings(params, 181);
+    SetupVector(params.Pos->theta, 0.0f, 360.0f, 181);
+    bhc::extsetup_rcvrranges(params, 1001);
+    SetupVector(params.Pos->Rr, 0.0f, 15.0f, 1001);
+    bhc::extsetup_rcvrdepths(params, 1);
+    params.Pos->Rz[0] = 50.0f;
+
+    // source beams
+    params.Angles->alpha.inDegrees = true;
+    params.Angles->beta.inDegrees  = true;
+    bhc::extsetup_raybearings(params, 144);
+    SetupVector(params.Angles->beta.angles, 0.0, 360.0, 144);
+    bhc::extsetup_rayelevations(params, 200);
+    SetupVector(params.Angles->alpha.angles, -14.66, 20.0, 200);
+
+    params.Beam->rangeInKm = true;
+    params.Beam->deltas    = 0.0;
+    params.Beam->Box.x     = 9.99;
+    params.Beam->Box.y     = 9.99;
+    params.Beam->Box.z     = 20500.0;
+
+    bhc::echo(params);
+    bhc::run(params, outputs);
+
+    bhc::writeenv(params, "test_province");
+    bhc::writeout(params, outputs, "test_province");
+
+    bhc::finalize(params, outputs);
+    return 0;
+}

--- a/examples/province.cpp
+++ b/examples/province.cpp
@@ -84,7 +84,6 @@ int GetProvince(int ix, int iy)
     }
 
     // shouldn't get here
-    return 1;
 }
 
 int main()
@@ -98,9 +97,9 @@ int main()
 
     bhc::setup(init, params, outputs);
 
-    strcpy(params.Title, "library province test");
+    strcpy_s(params.Title, sizeof(params.Title), "library province test");
 
-    strcpy(params.Beam->RunType, "IG   3");
+    strcpy_s(params.Beam->RunType, sizeof(params.Beam->RunType), "IG   3");
 
     params.freqinfo->freq0 = 100.0;
 
@@ -120,7 +119,7 @@ int main()
     params.ssp->dirty = true;
 
     // bottom params, mostly overridden, but makes the output file.
-    strcpy(params.Bdry->Bot.hs.Opt, "A~    ");
+    memcpy(params.Bdry->Bot.hs.Opt, "A~    ", 6);
     params.Bdry->Bot.hs.bc     = 'A';
     params.Bdry->Bot.hsx.Sigma = 0.0;
     params.Bdry->Bot.hsx.zTemp = 20000.0;
@@ -154,7 +153,7 @@ int main()
         params.bdinfo->bot.BotProv[cnt].betaI  = 0.0;
         ++cnt;
     }
-    strcpy(params.bdinfo->bot.type, "RL");
+    memcpy(params.bdinfo->bot.type, "RL", 2);
 
     params.bdinfo->top.dirty = true;
     params.bdinfo->bot.dirty = true;

--- a/examples/province.cpp
+++ b/examples/province.cpp
@@ -54,8 +54,8 @@ void FlatBoundary3D(
 {
     Boundary.dirty     = true;
     Boundary.rangeInKm = true;
-    Boundary.NPts[0]   = GridX.size();
-    Boundary.NPts[1]   = GridY.size();
+    Boundary.NPts[0]   = (int)GridX.size();
+    Boundary.NPts[1]   = (int)GridY.size();
 
     for(int iy = 0; iy < GridY.size(); ++iy) {
         for(int ix = 0; ix < GridX.size(); ++ix) {
@@ -117,9 +117,11 @@ int main()
         params.ssp->betaR[i]  = 0.0;
         params.ssp->betaI[i]  = 0.0;
     }
+    params.ssp->dirty = true;
 
     // bottom params, mostly overridden, but makes the output file.
     strcpy(params.Bdry->Bot.hs.Opt, "A~    ");
+    params.Bdry->Bot.hs.bc     = 'A';
     params.Bdry->Bot.hsx.Sigma = 0.0;
     params.Bdry->Bot.hsx.zTemp = 20000.0;
     params.Bdry->Bot.hs.alphaR = 1600.0;
@@ -171,7 +173,7 @@ int main()
     bhc::extsetup_rcvrranges(params, 1001);
     SetupVector(params.Pos->Rr, 0.0f, 15.0f, 1001);
     bhc::extsetup_rcvrdepths(params, 1);
-    params.Pos->Rz[0] = 50.0f;
+    params.Pos->Rz[0] = 100.0f;
 
     // source beams
     params.Angles->alpha.inDegrees = true;
@@ -190,7 +192,10 @@ int main()
     bhc::echo(params);
     bhc::run(params, outputs);
 
+    // generate the .env and associated files
     bhc::writeenv(params, "test_province");
+
+    // save the shd file for external use
     bhc::writeout(params, outputs, "test_province");
 
     bhc::finalize(params, outputs);

--- a/examples/province.cpp
+++ b/examples/province.cpp
@@ -101,7 +101,9 @@ int main()
 
     strcpy_s(params.Beam->RunType, sizeof(params.Beam->RunType), "IG   3");
 
-    params.freqinfo->freq0 = 100.0;
+    // awkward -- freq0 and freqVec are both used and not coordinated.
+    params.freqinfo->freq0      = 100.0;
+    params.freqinfo->freqVec[0] = params.freqinfo->freq0;
 
     // flat sound speed
     params.ssp->NPts = 3;

--- a/include/bhc/bhc.hpp
+++ b/include/bhc/bhc.hpp
@@ -207,11 +207,11 @@ extern template BHC_API void extsetup_altimetry<true>(
     bhcParams<true> &params, const IORI2<true> &NPts);
 /// See extsetup_altimetry.
 template<bool O3D> void extsetup_bathymetry(
-    bhcParams<O3D> &params, const IORI2<O3D> &NPts);
+    bhcParams<O3D> &params, const IORI2<O3D> &NPts, const int32_t &NBotProvinces);
 extern template BHC_API void extsetup_bathymetry<false>(
-    bhcParams<false> &params, const IORI2<false> &NPts);
+    bhcParams<false> &params, const IORI2<false> &NPts, const int32_t &NBotProvinces);
 extern template BHC_API void extsetup_bathymetry<true>(
-    bhcParams<true> &params, const IORI2<true> &NPts);
+    bhcParams<true> &params, const IORI2<true> &NPts, const int32_t &NBotProvinces);
 /**
  * Reallocate the top reflection coefficients to the given size. This also sets
  * params.Bdry->Top.hs.Opt[1] to 'F' (file) to use the reflection coefficients.

--- a/include/bhc/structs.hpp
+++ b/include/bhc/structs.hpp
@@ -172,12 +172,12 @@ template<bool O3D> constexpr int32_t BdryStride = sizeof(BdryPtFull<O3D>) / size
 
 template<bool O3D> struct BdryInfoTopBot {
     IORI2<O3D> NPts;
-    char type[2];        // In 3D, 2nd char is bathymetry type
-    bool dirty;          // Set to indicate that derived values need updating
-    bool rangeInKm;      // R, X, Y values in km; automatically converted to meters
-    BdryPtFull<O3D> *bd; // 2D: 1D array / 3D: 2D array
-    int32_t NBotProvinces;
-    HSInfo *BotProv;
+    char type[2];          // In 3D, 2nd char is bathymetry type
+    bool dirty;            // Set to indicate that derived values need updating
+    bool rangeInKm;        // R, X, Y values in km; automatically converted to meters
+    BdryPtFull<O3D> *bd;   // 2D: 1D array / 3D: 2D array
+    int32_t NBotProvinces; // only used in 3D
+    HSInfo *BotProv;       // only used in 3D
 };
 /**
  * LP: There are three boundary structures. This one represents static/global

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -671,18 +671,18 @@ template BHC_API void extsetup_altimetry<true>(
 #endif
 
 template<bool O3D> void extsetup_bathymetry(
-    bhcParams<O3D> &params, const IORI2<O3D> &NPts)
+    bhcParams<O3D> &params, const IORI2<O3D> &NPts, const int32_t &NBotProvinces = 0)
 {
     module::Bathymetry<O3D> pm;
-    pm.ExtSetup(params, NPts);
+    pm.ExtSetup(params, NPts, NBotProvinces);
 }
 #if BHC_ENABLE_2D
 template BHC_API void extsetup_bathymetry<false>(
-    bhcParams<false> &params, const IORI2<false> &NPts);
+    bhcParams<false> &params, const IORI2<false> &NPts, const int32_t &NBotProvinces = 0);
 #endif
 #if BHC_ENABLE_3D || BHC_ENABLE_NX2D
 template BHC_API void extsetup_bathymetry<true>(
-    bhcParams<true> &params, const IORI2<true> &NPts);
+    bhcParams<true> &params, const IORI2<true> &NPts, const int32_t &NBotProvinces = 0);
 #endif
 
 template<bool O3D> void extsetup_trc(bhcParams<O3D> &params, int32_t NPts)

--- a/src/boundary.hpp
+++ b/src/boundary.hpp
@@ -135,7 +135,7 @@ template<bool O3D> HOST_DEVICE inline void GetBdrySeg(
 
         if(bdinfotb->type[1] == 'L') {
             // grab the geoacoustic info for the new segment
-            int32_t iProv = bdinfotb->bd[bds.Iseg.x * ny + bds.Iseg.y].Province;
+            int32_t iProv = bdinfotb->bd[bds.Iseg.x * ny + bds.Iseg.y].Province - 1;
             CopyHSInfo(Bdry.hs, bdinfotb->BotProv[iProv]);
         }
 

--- a/src/boundary.hpp
+++ b/src/boundary.hpp
@@ -133,6 +133,12 @@ template<bool O3D> HOST_DEVICE inline void GetBdrySeg(
         bds.xmid = (bds.x + bdinfotb->bd[(bds.Iseg.x + 1) * ny + (bds.Iseg.y + 1)].x)
             * RL(0.5);
 
+        if(bdinfotb->type[1] == 'L') {
+            // grab the geoacoustic info for the new segment
+            int32_t iProv = bdinfotb->bd[bds.Iseg.x * ny + bds.Iseg.y].Province;
+            CopyHSInfo(Bdry.hs, bdinfotb->BotProv[iProv]);
+        }
+
         // printf("Iseg%s %d %d\n", isTop ? "Top" : "Bot", bds.Iseg.x+1, bds.Iseg.y+1);
         // printf("Bdryx %g,%g,%g x %g,%g,%g\n", bds.x.x, bds.x.y, bds.x.z, x.x, x.y,
         // x.z);

--- a/src/module/boundary.hpp
+++ b/src/module/boundary.hpp
@@ -35,6 +35,8 @@ public:
     {
         BdryInfoTopBot<O3D> *bdinfotb = GetBdryInfoTopBot(params);
         bdinfotb->bd                  = nullptr;
+        bdinfotb->NBotProvinces       = 0;
+        bdinfotb->BotProv             = nullptr;
     }
 
     virtual void SetupPre(bhcParams<O3D> &params) const override
@@ -315,16 +317,26 @@ public:
         BdryInfoTopBot<O3D> *bdinfotb = GetBdryInfoTopBot(params);
     }
 
-    void ExtSetup(bhcParams<O3D> &params, const IORI2<O3D> &NPts) const
+    void ExtSetup(
+        bhcParams<O3D> &params, const IORI2<O3D> &NPts,
+        const int32_t &NBotProvinces = 0) const
     {
         BdryInfoTopBot<O3D> *bdinfotb = GetBdryInfoTopBot(params);
         GetModeFlag(params)           = '~';
         bdinfotb->dirty               = true;
         bdinfotb->NPts                = NPts;
         if constexpr(O3D) {
+            bdinfotb->NBotProvinces = NBotProvinces;
             trackallocate(
                 params, s_altimetrybathymetry, bdinfotb->bd,
                 bdinfotb->NPts.x * bdinfotb->NPts.y);
+            if(bdinfotb->NBotProvinces == 0) {
+                trackdeallocate(params, bdinfotb->BotProv);
+            } else {
+                trackallocate(
+                    params, s_altimetrybathymetry, bdinfotb->BotProv,
+                    bdinfotb->NBotProvinces);
+            }
         } else {
             trackallocate(params, s_altimetrybathymetry, bdinfotb->bd, bdinfotb->NPts);
         }
@@ -526,7 +538,7 @@ public:
     virtual void Finalize(bhcParams<O3D> &params) const override
     {
         BdryInfoTopBot<O3D> *bdinfotb = GetBdryInfoTopBot(params);
-        if(bdinfotb->type[1] == 'L') { trackdeallocate(params, bdinfotb->BotProv); }
+        trackdeallocate(params, bdinfotb->BotProv);
         trackdeallocate(params, bdinfotb->bd);
     }
 

--- a/src/module/boundary.hpp
+++ b/src/module/boundary.hpp
@@ -281,17 +281,17 @@ public:
                 for(int32_t iy = 0; iy < bdinfotb->NPts.y; ++iy) {
                     for(int32_t ix = 0; ix < bdinfotb->NPts.x; ++ix) {
                         int32_t &prov = bdinfotb->bd[ix * bdinfotb->NPts.y + iy].Province;
-                        BDRYFile << prov << " ";
+                        BDRYFile << prov << ' ';
                     }
                     BDRYFile << '\n';
                 }
                 BDRYFile << bdinfotb->NBotProvinces << '\n';
                 for(int32_t iProv = 0; iProv < bdinfotb->NBotProvinces; ++iProv) {
-                    BDRYFile << bdinfotb->BotProv[iProv].alphaR << " "
-                             << bdinfotb->BotProv[iProv].betaR << " "
-                             << bdinfotb->BotProv[iProv].rho << " "
-                             << bdinfotb->BotProv[iProv].alphaI << " "
-                             << bdinfotb->BotProv[iProv].betaI << "\n";
+                    BDRYFile << bdinfotb->BotProv[iProv].alphaR << ' '
+                             << bdinfotb->BotProv[iProv].betaR << ' '
+                             << bdinfotb->BotProv[iProv].rho << ' '
+                             << bdinfotb->BotProv[iProv].alphaI << ' '
+                             << bdinfotb->BotProv[iProv].betaI << '\n';
                 }
             }
         } else {

--- a/src/module/boundary.hpp
+++ b/src/module/boundary.hpp
@@ -528,6 +528,7 @@ public:
     virtual void Finalize(bhcParams<O3D> &params) const override
     {
         BdryInfoTopBot<O3D> *bdinfotb = GetBdryInfoTopBot(params);
+        if(bdinfotb->type[1] == 'L') { trackdeallocate(params, bdinfotb->BotProv); }
         trackdeallocate(params, bdinfotb->bd);
     }
 

--- a/src/module/boundary.hpp
+++ b/src/module/boundary.hpp
@@ -146,7 +146,7 @@ public:
             trackdeallocate(params, Globaly);
 
             int32_t maxProvince = 0;
-            int32_t minProvince = 0;
+            int32_t minProvince = 1;
             if(bdinfotb->type[1] == 'L') {
                 PRTFile << "Province type\n";
                 // province numbers
@@ -189,7 +189,10 @@ public:
                             << bdinfotb->BotProv[iProv].betaI << "\n";
                 }
 
-                if(minProvince < 0 || maxProvince >= bdinfotb->NBotProvinces) {
+                if(minProvince < 1 || maxProvince > bdinfotb->NBotProvinces) {
+                    std::cout << "gh10 " << minProvince << " " << maxProvince << " "
+                              << bdinfotb->NBotProvinces << "\n"
+                              << std::flush;
                     EXTERR("BELLHOP3D: ReadBTY3D Matrix of provinces contains indices "
                            "for which province is undefined");
                 }
@@ -312,7 +315,6 @@ public:
     virtual void SetupPost(bhcParams<O3D> &params) const override
     {
         BdryInfoTopBot<O3D> *bdinfotb = GetBdryInfoTopBot(params);
-        if constexpr(O3D) bdinfotb->type[1] = ' ';
     }
 
     void ExtSetup(bhcParams<O3D> &params, const IORI2<O3D> &NPts) const
@@ -350,11 +352,6 @@ public:
         }
 
         if constexpr(O3D) {
-            if(bdinfotb->type[1] != ' ') {
-                EXTERR(
-                    "Read%s: %s option (type[1]) must be ' ' in Nx2D/3D mode\n", s_ATIBTY,
-                    s_altimetrybathymetry);
-            }
             if(!monotonic(
                    &bdinfotb->bd[0].x.x, bdinfotb->NPts.x,
                    bdinfotb->NPts.y * BdryStride<O3D>, 0)) {
@@ -515,17 +512,15 @@ public:
 
         ComputeBdryTangentNormal(params, bdinfotb);
 
-        if constexpr(!O3D) {
-            // convert range-dependent geoacoustic parameters from user to program units
-            if(bdinfotb->type[1] == 'L') {
-                for(int32_t iProv = 0; iProv < bdinfotb->NBotProvinces; ++iProv) {
-                    bdinfotb->BotProv[iProv].cP = crci(
-                        params, RL(1.0e20), bdinfotb->BotProv[iProv].alphaR,
-                        bdinfotb->BotProv[iProv].alphaI, {'W', ' '});
-                    bdinfotb->BotProv[iProv].cS = crci(
-                        params, RL(1.0e20), bdinfotb->BotProv[iProv].betaR,
-                        bdinfotb->BotProv[iProv].betaI, {'W', ' '});
-                }
+        // convert range-dependent geoacoustic parameters from user to program units
+        if(bdinfotb->type[1] == 'L') {
+            for(int32_t iProv = 0; iProv < bdinfotb->NBotProvinces; ++iProv) {
+                bdinfotb->BotProv[iProv].cP = crci(
+                    params, RL(1.0e20), bdinfotb->BotProv[iProv].alphaR,
+                    bdinfotb->BotProv[iProv].alphaI, {'W', ' '});
+                bdinfotb->BotProv[iProv].cS = crci(
+                    params, RL(1.0e20), bdinfotb->BotProv[iProv].betaR,
+                    bdinfotb->BotProv[iProv].betaI, {'W', ' '});
             }
         }
     }

--- a/src/module/boundary.hpp
+++ b/src/module/boundary.hpp
@@ -342,11 +342,7 @@ public:
             }
             break;
         case 'C': break;
-        case 'L':
-            if constexpr(O3D) {
-                EXTERR("%sType L not supported for 3D runs\n", s_atibty);
-            }
-            break;
+        case 'L': break;
         default:
             EXTERR(
                 "Read%s: Unknown option for selecting %s interpolation", s_ATIBTY,

--- a/src/module/boundary.hpp
+++ b/src/module/boundary.hpp
@@ -518,15 +518,13 @@ public:
         if constexpr(!O3D) {
             // convert range-dependent geoacoustic parameters from user to program units
             if(bdinfotb->type[1] == 'L') {
-                for(int32_t iSeg = 0; iSeg < bdinfotb->NPts; ++iSeg) {
-                    // compressional wave speed
-                    bdinfotb->bd[iSeg].hs.cP = crci(
-                        params, RL(1.0e20), bdinfotb->bd[iSeg].hs.alphaR,
-                        bdinfotb->bd[iSeg].hs.alphaI, {'W', ' '});
-                    // shear         wave speed
-                    bdinfotb->bd[iSeg].hs.cS = crci(
-                        params, RL(1.0e20), bdinfotb->bd[iSeg].hs.betaR,
-                        bdinfotb->bd[iSeg].hs.betaI, {'W', ' '});
+                for(int32_t iProv = 0; iProv < bdinfotb->NBotProvinces; ++iProv) {
+                    bdinfotb->BotProv[iProv].cP = crci(
+                        params, RL(1.0e20), bdinfotb->BotProv[iProv].alphaR,
+                        bdinfotb->BotProv[iProv].alphaI, {'W', ' '});
+                    bdinfotb->BotProv[iProv].cS = crci(
+                        params, RL(1.0e20), bdinfotb->BotProv[iProv].betaR,
+                        bdinfotb->BotProv[iProv].betaI, {'W', ' '});
                 }
             }
         }

--- a/src/module/boundary.hpp
+++ b/src/module/boundary.hpp
@@ -161,8 +161,9 @@ public:
                         maxProvince = bhc::max(
                             maxProvince,
                             bdinfotb->bd[ix * bdinfotb->NPts.y + iy].Province);
+                        PRTFile << x << " ";
                     }
-                    PRTFile << bdinfotb->bd[iy].Province << "\n";
+                    PRTFile << "\n";
                 }
 
                 LIST(BDRYFile);
@@ -190,9 +191,6 @@ public:
                 }
 
                 if(minProvince < 1 || maxProvince > bdinfotb->NBotProvinces) {
-                    std::cout << "gh10 " << minProvince << " " << maxProvince << " "
-                              << bdinfotb->NBotProvinces << "\n"
-                              << std::flush;
                     EXTERR("BELLHOP3D: ReadBTY3D Matrix of provinces contains indices "
                            "for which province is undefined");
                 }


### PR DESCRIPTION
Supports a variable bottom profile. This is a new feature in oalib bellhop as of 2024.
Test:
1. Compile and code review. Larger change than usual.
2. Run the new province.exe test program to create test_province.shd file and .env/.bty files.
3. plot the test_province.shd file in matlab. Use the snippet below 
4. Run the test_province env in the normal way, e.g., `bellhopcxx.exe -3 test_province`
5. plot again and check that the output is the same
6. compare to the reference output (image below or run it with 2024 fortran)

reference image: 
![oalib_bellhop3d_province](https://github.com/user-attachments/assets/a9c543a0-174d-4da6-90f6-9f3ed44db807)

recommended matlab code (be sure to include the at_2022 directory for bhc)
```{matlab}
global units
units = 'km';
figure
plotshdpol( 'provinces.shd', 0, 0, 50 )
axis( [ -10 10 -10 10 ] )
caxisrev( [ 60 80 ] )
```
