### PR TITLE
Shade output

### DIFF
--- a/examples/province.cpp
+++ b/examples/province.cpp
@@ -170,11 +170,11 @@ int main()
     // disk of receivers
     params.Pos->RrInKm = true;
     bhc::extsetup_rcvrbearings(params, 181);
-    SetupVector(params.Pos->theta, 0.0f, 360.0f, 181);
+    SetupVector(params.Pos->theta, 0.0, 360.0, 181);
     bhc::extsetup_rcvrranges(params, 1001);
-    SetupVector(params.Pos->Rr, 0.0f, 15.0f, 1001);
+    SetupVector(params.Pos->Rr, 0.0, 15.0, 1001);
     bhc::extsetup_rcvrdepths(params, 1);
-    params.Pos->Rz[0] = 100.0f;
+    params.Pos->Rz[0] = 100.0;
 
     // source beams
     params.Angles->alpha.inDegrees = true;

--- a/include/bhc/structs.hpp
+++ b/include/bhc/structs.hpp
@@ -285,8 +285,10 @@ struct Position {
     bool thetaDuplRemoved;
     real Delta_r, Delta_theta;
     // int32_t *iSz, *iRz; // LP: Not used.
-    real *Sx, *Sy, *Sz; // Source x, y, z coordinates
-    real *Rr, *Rz;      // Receiver r, z coordinates
+    real *Sx, *Sy; // Source x, y coordinates
+    float *Sz; // Source z coordinates
+    real *Rr; // Receiver r coordinates
+    float *Rz; // Receiver z coordinates
     // float *ws, *wr; // weights for interpolation LP: Not used.
     real *theta;  // Receiver bearings
     vec2 *t_rcvr; // Receiver directions (cos(theta), sin(theta))

--- a/include/bhc/structs.hpp
+++ b/include/bhc/structs.hpp
@@ -285,11 +285,10 @@ struct Position {
     bool thetaDuplRemoved;
     real Delta_r, Delta_theta;
     // int32_t *iSz, *iRz; // LP: Not used.
-    // LP: These are really floats, not reals.
-    float *Sx, *Sy, *Sz; // Source x, y, z coordinates
-    float *Rr, *Rz;      // Receiver r, z coordinates
+    real *Sx, *Sy, *Sz; // Source x, y, z coordinates
+    real *Rr, *Rz;      // Receiver r, z coordinates
     // float *ws, *wr; // weights for interpolation LP: Not used.
-    float *theta; // Receiver bearings
+    real *theta;  // Receiver bearings
     vec2 *t_rcvr; // Receiver directions (cos(theta), sin(theta))
 };
 

--- a/src/influence.hpp
+++ b/src/influence.hpp
@@ -1555,7 +1555,7 @@ template<typename CFG, bool O3D, bool R3D> HOST_DEVICE inline bool Step_Influenc
  */
 template<bool O3D, bool R3D> HOST_DEVICE inline void ScalePressure(
     real Dalpha, [[maybe_unused]] real Dbeta, real c, [[maybe_unused]] cpx epsilon1,
-    [[maybe_unused]] cpx epsilon2, float *r, cpxf *u, int32_t Ntheta, int32_t NRz,
+    [[maybe_unused]] cpx epsilon2, real *r, cpxf *u, int32_t Ntheta, int32_t NRz,
     int32_t Nr, real freq, const BeamStructure<O3D> *Beam)
 {
     real cnst;

--- a/src/mode/arr.cpp
+++ b/src/mode/arr.cpp
@@ -261,7 +261,7 @@ template<typename T> void ReadArrivalsValue(
 
 template<bool O3D> inline void ReadArrivalsArray(
     bhcParams<O3D> &params, LDIFile &AARRFile, UnformattedIFile &BARRFile, bool isAscii,
-    float *&v, int32_t &nv, const char *description)
+    real *&v, int32_t &nv, const char *description)
 {
     ReadArrivalsValue(AARRFile, BARRFile, isAscii, nv, true);
     trackallocate(params, description, v, nv);

--- a/src/mode/arr.cpp
+++ b/src/mode/arr.cpp
@@ -259,9 +259,9 @@ template<typename T> void ReadArrivalsValue(
     }
 }
 
-template<bool O3D> inline void ReadArrivalsArray(
+template<bool O3D, class T> inline void ReadArrivalsArray(
     bhcParams<O3D> &params, LDIFile &AARRFile, UnformattedIFile &BARRFile, bool isAscii,
-    real *&v, int32_t &nv, const char *description)
+    T *&v, int32_t &nv, const char *description)
 {
     ReadArrivalsValue(AARRFile, BARRFile, isAscii, nv, true);
     trackallocate(params, description, v, nv);

--- a/src/mode/tl.cpp
+++ b/src/mode/tl.cpp
@@ -36,7 +36,7 @@ namespace bhc { namespace mode {
  * "TL" in BELLHOP]
  */
 template<bool O3D> inline void WriteHeader(
-    const bhcParams<O3D> &params, DirectOFile &SHDFile, float atten,
+    const bhcParams<O3D> &params, DirectOFile &SHDFile, real atten,
     const std::string &PlotType)
 {
     const Position *Pos      = params.Pos;
@@ -71,7 +71,7 @@ template<bool O3D> inline void WriteHeader(
     DOFWRITEV(SHDFile, Pos->NSz);
     DOFWRITEV(SHDFile, Pos->NRz);
     DOFWRITEV(SHDFile, Pos->NRr);
-    DOFWRITEV(SHDFile, (float)freqinfo->freq0);
+    DOFWRITEV(SHDFile, freqinfo->freq0);
     DOFWRITEV(SHDFile, atten);
     SHDFile.rec(3);
     DOFWRITE(SHDFile, freqinfo->freqVec, freqinfo->Nfreq * sizeof(freqinfo->freqVec[0]));

--- a/src/module/rcvrbearings.hpp
+++ b/src/module/rcvrbearings.hpp
@@ -86,10 +86,10 @@ public:
             PrintFileEmu &PRTFile = GetInternal(params)->PRTFile;
             Preprocess(params);
             EchoVectorWDescr(
-                params, params.Pos->theta, params.Pos->Ntheta, FL(1.0), Description,
+                params, params.Pos->theta, params.Pos->Ntheta, RL(1.0), Description,
                 Units);
             if(params.Pos->thetaDuplRemoved) {
-                PRTFile << "(Duplicate angle at " << params.Pos->theta[0] + FL(360.0)
+                PRTFile << "(Duplicate angle at " << params.Pos->theta[0] + RL(360.0)
                         << " degrees removed--this occurs in BELLHOP(3D) too,\n"
                            "but that version echoes the vector before removing the "
                            "duplicate)\n";

--- a/src/module/rcvrranges.hpp
+++ b/src/module/rcvrranges.hpp
@@ -49,7 +49,7 @@ public:
     virtual void Write(bhcParams<O3D> &params, LDOFile &ENVFile) const
     {
         UnSubTab(
-            ENVFile, params.Pos->Rr, params.Pos->NRr, "NR", "R(1:NR ) (km)", FL(0.001));
+            ENVFile, params.Pos->Rr, params.Pos->NRr, "NR", "R(1:NR ) (km)", RL(0.001));
     }
     virtual void SetupPost(bhcParams<O3D> &params) const override
     {
@@ -69,7 +69,7 @@ public:
     {
         Preprocess(params);
         EchoVectorWDescr(
-            params, params.Pos->Rr, params.Pos->NRr, FL(0.001), Description, Units);
+            params, params.Pos->Rr, params.Pos->NRr, RL(0.001), Description, Units);
     }
     virtual void Preprocess(bhcParams<O3D> &params) const override
     {

--- a/src/module/sxsy.hpp
+++ b/src/module/sxsy.hpp
@@ -62,10 +62,10 @@ public:
         if constexpr(O3D) {
             UnSubTab(
                 ENVFile, params.Pos->Sx, params.Pos->NSx, "NSX", "SX(1:NSX) (km)",
-                FL(0.001));
+                RL(0.001));
             UnSubTab(
                 ENVFile, params.Pos->Sy, params.Pos->NSy, "NSY", "SY(1:NSY) (km)",
-                FL(0.001));
+                RL(0.001));
         }
     }
     void ExtSetup(bhcParams<O3D> &params, int32_t NSx, int32_t NSy) const
@@ -97,9 +97,9 @@ public:
         if constexpr(O3D) {
             Preprocess(params);
             EchoVectorWDescr(
-                params, params.Pos->Sx, params.Pos->NSx, FL(0.001), DescriptionX, Units);
+                params, params.Pos->Sx, params.Pos->NSx, RL(0.001), DescriptionX, Units);
             EchoVectorWDescr(
-                params, params.Pos->Sy, params.Pos->NSy, FL(0.001), DescriptionY, Units);
+                params, params.Pos->Sy, params.Pos->NSy, RL(0.001), DescriptionY, Units);
         }
     }
     virtual void Preprocess(bhcParams<O3D> &params) const override

--- a/src/module/szrz.hpp
+++ b/src/module/szrz.hpp
@@ -131,9 +131,9 @@ public:
     virtual void Echo(bhcParams<O3D> &params) const override
     {
         EchoVectorWDescr(
-            params, params.Pos->Sz, params.Pos->NSz, RL(1.0), DescriptionS, Units);
+            params, params.Pos->Sz, params.Pos->NSz, FL(1.0), DescriptionS, Units);
         EchoVectorWDescr(
-            params, params.Pos->Rz, params.Pos->NRz, RL(1.0), DescriptionR, Units);
+            params, params.Pos->Rz, params.Pos->NRz, FL(1.0), DescriptionR, Units);
     }
     virtual void Preprocess(bhcParams<O3D> &params) const override
     {

--- a/src/module/szrz.hpp
+++ b/src/module/szrz.hpp
@@ -131,9 +131,9 @@ public:
     virtual void Echo(bhcParams<O3D> &params) const override
     {
         EchoVectorWDescr(
-            params, params.Pos->Sz, params.Pos->NSz, FL(1.0), DescriptionS, Units);
+            params, params.Pos->Sz, params.Pos->NSz, RL(1.0), DescriptionS, Units);
         EchoVectorWDescr(
-            params, params.Pos->Rz, params.Pos->NRz, FL(1.0), DescriptionR, Units);
+            params, params.Pos->Rz, params.Pos->NRz, RL(1.0), DescriptionR, Units);
     }
     virtual void Preprocess(bhcParams<O3D> &params) const override
     {


### PR DESCRIPTION
Makes the output compatible with 2024 acoustic library bellhop.
Test:
1. run the test suite for comparing using the 2024 matlab routines.
2. After that we can merge and push into main and a new release