### PR TITLE
floating point equality

### DIFF
--- a/src/common.hpp
+++ b/src/common.hpp
@@ -203,6 +203,12 @@ HOST_DEVICE constexpr inline cpx Cpxf2Cpx(const cpxf &c)
     return cpx((real)c.real(), (real)c.imag());
 }
 
+inline HOST_DEVICE bool NearlyZero(const cpx &x) { return STD::abs(x) < REAL_EPSILON; }
+inline HOST_DEVICE bool NotNearlyZero(const cpx &x)
+{
+    return STD::abs(x) >= REAL_EPSILON;
+}
+
 // CUDA::std::cpx<double> and glm::mat2x2 do not like operators being applied
 // with float literals, due to template type deduction issues.
 #ifndef BHC_USE_FLOATS
@@ -234,6 +240,12 @@ HOST_DEVICE inline mat2x2 operator*(float a, const mat2x2 &b) { return (double)a
 #define CUBE(a) ((a) * (a) * (a))
 constexpr real RadDeg = RL(180.0) / REAL_PI;
 constexpr real DegRad = REAL_PI / RL(180.0);
+
+inline HOST_DEVICE bool NearlyZero(const real &x) { return STD::fabs(x) < REAL_EPSILON; }
+inline HOST_DEVICE bool NotNearlyZero(const real &x)
+{
+    return STD::fabs(x) >= REAL_EPSILON;
+}
 
 template<typename REAL> HOST_DEVICE inline REAL spacing(REAL v)
 {

--- a/src/common_run.hpp
+++ b/src/common_run.hpp
@@ -146,7 +146,7 @@ HOST_DEVICE inline void RayNormalImpl(
 {
     real rl = glm::length(vec2(t.x, t.y));
 
-    if(phi != RL(0.0) || ignorephi0) {
+    if(NotNearlyZero(phi) || ignorephi0) {
         real cosphi = STD::cos(phi), sinphi = STD::sin(phi);
 
         // e1

--- a/src/influence.hpp
+++ b/src/influence.hpp
@@ -228,7 +228,7 @@ template<bool O3D, bool R3D> HOST_DEVICE inline cpx PickEpsilon(
             } else {
                 halfwidth  = REAL_MAX;
                 real cz    = DEP(gradc);
-                epsilonOpt = (cz == FL(0.0))
+                epsilonOpt = NearlyZero(cz)
                     ? RL(1e10)
                     : ((-STD::sin(angle) / STD::cos(SQ(angle))) * c * c / cz);
             }
@@ -258,8 +258,8 @@ template<bool O3D, bool R3D> HOST_DEVICE inline cpx PickEpsilon(
         epsilonOpt = FL(0.0);
     } else if(defaultEps) {
         if(defaultHalfwidth) {
-            halfwidth = (Dangle == FL(0.0)) ? FL(0.0)
-                                            : (FL(2.0) / ((omega / c) * Dangle));
+            halfwidth = (NearlyZero(Dangle)) ? FL(0.0)
+                                             : (FL(2.0) / ((omega / c) * Dangle));
         }
         epsilonOpt = J * FL(0.5) * omega * SQ(halfwidth);
     }
@@ -290,7 +290,7 @@ template<typename CFG, bool O3D> HOST_DEVICE inline cpx Compute_gamma(
     real Tr = rayt.x;
     real Tz = rayt.y;
 
-    if(qB != RL(0.0)) {
+    if(NotNearlyZero(qB)) {
         return FL(0.5)
             * (pB / qB * SQ(Tr) + FL(2.0) * cN / csq * Tz * Tr - cS / csq * SQ(Tz));
     } else {
@@ -921,7 +921,7 @@ template<typename CFG, bool O3D, bool R3D> HOST_DEVICE inline void InfluenceGeoC
         if constexpr(CFG::infl::IsCartesian()) {
             real l1 = glm::length(glm::row(qInterp, 0));
             real l2 = glm::length(glm::row(qInterp, 1));
-            if(l1 == FL(0.0) || l2 == FL(0.0)) {
+            if(NearlyZero(l1) || NearlyZero(l2)) {
 #ifdef INFL_DEBUGGING_IR
                 if(itheta == INFL_DEBUGGING_ITHETA && ir == INFL_DEBUGGING_IR
                    && iz == INFL_DEBUGGING_IZ) {
@@ -934,7 +934,7 @@ template<typename CFG, bool O3D, bool R3D> HOST_DEVICE inline void InfluenceGeoC
             }
         }
 
-        if(qFinal == FL(0.0)) {
+        if(NearlyZero(qFinal)) {
 // receiver is outside the beam
 #ifdef INFL_DEBUGGING_IR
             if(itheta == INFL_DEBUGGING_ITHETA && ir == INFL_DEBUGGING_IR
@@ -1610,7 +1610,7 @@ template<bool O3D, bool R3D> HOST_DEVICE inline void ScalePressure(
                 const float local_pi = 3.14159265f;
                 factor               = FL(-4.0) * STD::sqrt(local_pi) * cnst;
             } else {
-                if(r[ir] == 0.0f) {
+                if(NearlyZero(r[ir])) {
                     factor = RL(0.0); // avoid /0 at origin, return pressure = 0
                 } else {
                     factor = cnst / (real)STD::sqrt(STD::abs(r[ir]));

--- a/src/mode/arr.cpp
+++ b/src/mode/arr.cpp
@@ -52,7 +52,7 @@ template<bool O3D, bool R3D> void PostProcessArrivals(
                                 if constexpr(!O3D) line = IsLineSource(params.Beam);
                                 if(line) {
                                     factor = FL(4.0) * STD::sqrt(REAL_PI);
-                                } else if(Pos->Rr[ir] == FL(0.0)) {
+                                } else if(NearlyZero(Pos->Rr[ir])) {
                                     // avoid /0 at origin
                                     factor = FL(1e5);
                                 } else {

--- a/src/module/atten.cpp
+++ b/src/module/atten.cpp
@@ -130,16 +130,16 @@ template<bool O3D> cpx crci(
         alphaT = alpha * freq / RL(8685.8896);
         break;
     case 'W': // dB/wavelength
-        if(c != FL(0.0)) alphaT = alpha * freq / (RL(8.6858896) * c);
+        if(NotNearlyZero(c)) alphaT = alpha * freq / (RL(8.6858896) * c);
         // The following lines give f^1.25 frequency dependence
         // real FAC = STD::sqrt(STD::sqrt(freq / FL(50.0)));
         // if(c != FL(0.0)) alphaT = FAC * alpha * freq / (RL(8.6858896) * c);
         break;
     case 'Q': // Quality factor
-        if(c * alpha != FL(0.0)) alphaT = omega / (FL(2.0) * c * alpha);
+        if(NotNearlyZero(c * alpha)) alphaT = omega / (FL(2.0) * c * alpha);
         break;
     case 'L': // loss parameter
-        if(c != FL(0.0)) alphaT = alpha * omega / c;
+        if(NotNearlyZero(c)) alphaT = alpha * omega / c;
         break;
     }
 

--- a/src/module/beaminfo.hpp
+++ b/src/module/beaminfo.hpp
@@ -230,7 +230,7 @@ public:
         }
 
         // Automatic step size selection
-        if(Beam->deltas == FL(0.0)) {
+        if(NearlyZero(Beam->deltas)) {
             Beam->deltas = (params.Bdry->Bot.hs.Depth - params.Bdry->Top.hs.Depth)
                 / FL(10.0);
             Beam->autoDeltas = true;

--- a/src/module/rayangles.hpp
+++ b/src/module/rayangles.hpp
@@ -120,7 +120,7 @@ public:
     {
         AngleInfo &a = GetAngle(params);
         if constexpr(BEARING && !O3D) {
-            if(a.n != 1 || a.angles[0] != RL(0.0)) {
+            if(a.n != 1 || NotNearlyZero(a.angles[0])) {
                 EXTERR("Invalid beam bearing angles setup for 2D");
             }
         } else {

--- a/src/module/rcvrbearings.hpp
+++ b/src/module/rcvrbearings.hpp
@@ -73,7 +73,7 @@ public:
     virtual void Validate(bhcParams<O3D> &params) const override
     {
         if constexpr(!O3D) {
-            if(params.Pos->Ntheta != 1 || params.Pos->theta[0] != RL(0.0)) {
+            if(params.Pos->Ntheta != 1 || NotNearlyZero(params.Pos->theta[0])) {
                 EXTERR("Invalid receiver bearings setup for 2D");
             }
         } else {

--- a/src/module/sxsy.hpp
+++ b/src/module/sxsy.hpp
@@ -84,7 +84,7 @@ public:
         }
         if constexpr(!O3D) {
             if(params.Pos->NSx != 1 || params.Pos->NSy != 1
-               || params.Pos->Sx[0] != RL(0.0) || params.Pos->Sy[0] != RL(0.0)) {
+               || NotNearlyZero(params.Pos->Sx[0]) || NotNearlyZero(params.Pos->Sy[0])) {
                 EXTERR("Invalid Sx/Sy setup for 2D case");
             }
         } else {

--- a/src/reflect.hpp
+++ b/src/reflect.hpp
@@ -341,7 +341,7 @@ template<typename CFG, bool O3D, bool R3D> HOST_DEVICE inline void Reflect(
                 // Intel and GFortran compilers return different branches of the SQRT for
                 // negative reals LP: looks like this just means we want the positive
                 // branch
-                if(kzP.real() == RL(0.0) && kzP.imag() < RL(0.0)) kzP = -kzP;
+                if(NearlyZero(kzP.real()) && kzP.imag() < RL(0.0)) kzP = -kzP;
                 f = kzP;
                 g = hs.rho;
             }
@@ -395,7 +395,7 @@ template<typename CFG, bool O3D, bool R3D> HOST_DEVICE inline void Reflect(
                     real ssi = SQ(si);
 
                     cpx delta;
-                    if(si != FL(0.0)) {
+                    if(NotNearlyZero(si)) {
                         delta = a * co / si / (ck * sb * d); // Do we need an abs() on
                                                              // this???
                     } else {

--- a/src/step.hpp
+++ b/src/step.hpp
@@ -513,8 +513,8 @@ template<bool REFLECTVERSION> HOST_DEVICE inline void CurvatureCorrection3D(
 
     bool noCurvatureChange = false; // Silence MSVC warning
     if constexpr(REFLECTVERSION) {
-        noCurvatureChange = rmat[0][0] == RL(0.0) && rmat[0][1] == RL(0.0)
-            && rmat[1][1] == RL(0.0);
+        noCurvatureChange = NearlyZero(rmat[0][0]) && NearlyZero(rmat[0][1])
+            && NearlyZero(rmat[1][1]);
     }
     if(noCurvatureChange) {
         // LP: There is no curvature change, but rotating p forward and back


### PR DESCRIPTION
Equality testing of floats failed in some cases, so I removed all equality tests I could find and replaced with NearlyZero. In a very few spots, the equality testing is intentional for some outputting.
Test:
1. Code review and let me know if I missed any equality tests.
2. Check that the toolbox tests Bellhop3DTests/LloydMirror work on cxx and cuda (LloydMirror_3D used to fail on CUDA)