### PR TITLE
ncore cmdline support

### DIFF
--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -77,6 +77,8 @@ void showhelp(const char *argv0)
            " should use.\n"
            "    X may have a wide range of suffixes, examples: 16GiB, 8M, 100000kB\n"
            "    non-examples: 4gI, 2m, 5.3G. Default: 4GiB\n"
+           "-ncore=num: Sets the number of worker threads to use for CPU computation. Default: -1\n"
+           "    (all logical cores)\n"
            "-writeenv=\"path/to/newFileRoot\": For testing purposes, writes out\n"
            "    a copy of all the input data read from the environment file etc.\n"
            "    to a new environment file and other data files. Does not run the\n"
@@ -123,6 +125,14 @@ int main(int argc, char **argv)
                         return 1;
                     }
                     init.gpuIndex = std::stoi(value);
+                } else if(key == "-ncore") {
+                    if(!bhc::isInt(value, true)) {
+                        std::cout << "Value \"" << value
+                                  << "\" for --ncore argument is invalid, try " << argv[0]
+                                  << " --help\n";
+                        return 1;
+                    }
+                    init.numThreads = std::stoi(value);
                 } else if(key == "-mem" || key == "-memory") {
                     size_t multiplier = 1u;
                     size_t base       = 1000u;


### PR DESCRIPTION
Add a setting for ncore in the command line.
Test:
1. Pick a small .env file that you know works and takes a few seconds to run. The built in test_province.env would work fine.
2. Run the c++ version as `bellhopcxx -3 -ncore=2 test_province` (or whatever file you use) and check that only two CPUs are accessed.
3. Run again with `bellhopcxx -3 test_province` and check it uses all CPUs
4. (Optional) Check the GPU version is unaffected

Note: minor, but useful, change, so just pull into main.